### PR TITLE
update user.last_login when running level 3 methods; updates #337

### DIFF
--- a/okapi/service_runner.php
+++ b/okapi/service_runner.php
@@ -134,6 +134,13 @@ class OkapiServiceRunner
             require_once($GLOBALS['rootpath']."okapi/$service_name.php");
             $response = call_user_func(array('\\okapi\\'.
                 str_replace('/', '\\', $service_name).'\\WebService', 'call'), $request);
+            if ($options['min_auth_level'] >= 3)
+            {
+                Db::execute("
+                    update user set last_login=now()
+                    where user_id='".mysql_real_escape_string($request->token->user_id)."'
+                ");
+            }
             Okapi::gettext_domain_restore();
         } catch (Exception $e) {
             Okapi::gettext_domain_restore();


### PR DESCRIPTION
I have tested this with `>= 3` changed to `>= 1` and `$request->token->user_id` replaced by a constant number, as I currently do not have any oauth enabled OKAPI client available for testing.