### PR TITLE
started changelog

### DIFF
--- a/etc/changes.xml
+++ b/etc/changes.xml
@@ -8,6 +8,11 @@
 
     New entries are inserted at the top with EMPTY version number and date.
     Then run update_changes.php to insert the version numbers and dates.
+
+    Only one entry per commit. If multiple things were changed with one
+    commit, put them into one entry. This helps to detect copy-and-paste
+    errors, and allows commmit IDs or version numbers to be used as unique
+    identifiers for changelog entries.
    
     -->
     <changes>
@@ -71,9 +76,7 @@
             Improved posting plaintext logs on OCPL sites.
         </change>
         <change commit="28825396" version="1125" time="2015-12-22T19:12:16+0100" type="enhancement">
-            Enabled full 32-bit Unicode for submitting logs on some OC sites.
-            Use <a href="services/apisrv/installation.html">services/apisrv/installation</a>
-            to find out the <em>submit_charset</em> of an OC site.
+            Enabled full 21-bit Unicode for submitting logs on some OC sites.
         </change>
         <change commit="b2d31a34" version="1119" time="2015-11-26T14:11:51+0100" type="bugfix">
             Solved rare problem when searching by distance or bbox

--- a/etc/changes.xml
+++ b/etc/changes.xml
@@ -1,67 +1,73 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<xml>
+    <!--
 
-This is an incomplete list of changes in the OKAPI interface.
-Please add only changes which are relevant for client developers
-or site admins.
+    This is an incomplete list of changes in the OKAPI interface.
+    Please add only changes which are relevant for client developers
+    or site admins.
 
-New entries are inserted at the top with EMPTY version number
-and date. Run update_changes.php to insert the version numbers
-and dates.
-
--->
-<changes>
-    <change commit="93cfc2d9" version="1237" date="2016-03-31" type="enhancement">
-        New methods for &lt;a href="services/logs/images/add.html"&gt;adding&lt;/a&gt;,
-        &lt;a href="services/logs/images/edit.html"&gt;editing&lt;/a&gt; and
-        &lt;a href="services/logs/images/delete.html"&gt;deleting&lt;/a&gt; log images.
-    </change>
-    <change commit="cf97cb2f" version="1200" date="2016-03-17" type="enhancement">
-        Consumer keys may be revoked by OC site admins.
-    </change>
-    <change commit="31061755" version="1194" date="2016-03-17" type="bugfix">
-        &lt;a href="services/oauth/authorize.html"&gt;services/oauth/authorize&lt;/a&gt;
-        will no longer delete Opencaching.DE cookies when called with parameter
-        &lt;i&gt;interactivity=confirm_user&lt;/i&gt;.
-    </change>
-    <change commit="3dbe4760" version="1184" date="2016-03-14" type="enhancement">
-        OCDE geocache log entries with and without time are more reasonably
-        ordered. Developers are recommended to keep the order as returned by
-        OKAPI instead of ordering by the log date.
-    </change>
-    <change commit="a711d95c" version="1183" date="2016-03-13" type="enhancement">
-        Registration date of users can be retrieved.
-    </change>
-    <change commit="28f4cefd" version="1177" date="2016-03-12" type="enhancement">
-        Added the 'needs maintenance' flag to log entries and geocaches.
-    </change>
-    <change commit="58474a4d" version="1169" date="2016-03-11" type="enhancement">
-        Added Romanian translation.
-    </change>
-    <change commit="f24c7ac2" version="1154" date="2016-03-04" type="enhancement">
-        For caches with the mark 'listing is outdated' (available only on some
-        OC sites), a corresponding message is prepended to the description
-        field. DO NOT rely on this message being there or having a certain
-        content. It may be changed in the future.
-    </change>
-    <change commit="a9a2a042" version="1145" date="2016-02-10" type="enhancement">
-        The home location of users can be queried, if given in the user's
-        profile (OAuth level 3).
-    </change>
-    <change commit="54ad2cf8" version="1133" date="2016-01-16" type="enhancement">
-        The URL of the OC site's registration page can be retrieved via
-        &lt;a href="services/apisrv/installation.html"&gt;apisrv/installation&lt;/a&gt;.
-    </change>
-    <change commit="834fdd9b" version="1132" date="2016-01-15" type="bugfix">
-        Restored the Opencaching.com namespace definition for GPX.
-    </change>
-    <change commit="24a12af0" version="1131" date="2016-01-15" type="docs">
-        Clarified the documentation on
-        &lt;a href="services/logs/submit.html"&gt;submitting log entries&lt;/a&gt;
-        without time.
-    </change>
-    <change commit="08ee9b59" version="1127" date="2016-01-14" type="enhancement">
-        Allowed to search for &lt;em&gt;multiple&lt;/em&gt; users that (not)
-        found a geocache.
-    </change>
-</changes>
+    New entries are inserted at the top with EMPTY version number and date.
+    Run update_changes.php to insert the version numbers and dates.
+   
+    -->
+    <changes>
+        <change commit="93cfc2d9" version="1237" date="2016-03-31" type="enhancement">
+            New methods for <a href="services/logs/images/add.html">adding</a>,
+            <a href="services/logs/images/edit.html">editing</a> and
+            <a href="services/logs/images/delete.html">deleting</a> log images.
+        </change>
+        <change commit="cf97cb2f" version="1200" date="2016-03-17" type="enhancement">
+            Consumer keys may be revoked by OC site admins.
+        </change>
+        <change commit="31061755" version="1194" date="2016-03-17" type="bugfix">
+            <a href="services/oauth/authorize.html">services/oauth/authorize</a>
+            will no longer delete Opencaching.DE cookies when called with parameter
+            <i>interactivity=confirm_user</i>.
+        </change>
+        <change commit="3dbe4760" version="1184" date="2016-03-14" type="enhancement">
+            OCDE geocache log entries with and without time are more reasonably
+            ordered. Developers are recommended to keep the order as returned by
+            OKAPI instead of ordering by the log date.
+        </change>
+        <change commit="a711d95c" version="1183" date="2016-03-13" type="enhancement">
+            The registration date of users can be retrieved.
+        </change>
+        <change commit="28f4cefd" version="1177" date="2016-03-12" type="enhancement">
+            Added the 'needs maintenance' flag to log entries and geocaches.
+        </change>
+        <change commit="58474a4d" version="1169" date="2016-03-11" type="enhancement">
+            Added Romanian translation.
+        </change>
+        <change commit="f24c7ac2" version="1154" date="2016-03-04" type="enhancement">
+            For caches with the mark 'listing is outdated' (available only on some
+            OC sites), a corresponding message is prepended to the description
+            field. DO NOT rely on this message being there or having a certain
+            content. It may be changed in the future.
+        </change>
+        <change commit="a9a2a042" version="1145" date="2016-02-10" type="enhancement">
+            The home location of users can be queried, if given in the user's
+            profile (requires OAuth level 3).
+        </change>
+        <change commit="54ad2cf8" version="1133" date="2016-01-16" type="enhancement">
+            The URL of the OC site's registration page can be retrieved via
+            <a href="services/apisrv/installation.html">apisrv/installation</a>.
+        </change>
+        <change commit="834fdd9b" version="1132" date="2016-01-15" type="bugfix">
+            Restored the OpenCaching.com namespace definition for GPX.
+        </change>
+        <change commit="24a12af0" version="1131" date="2016-01-15" type="docs">
+            Clarified the documentation on
+            <a href="services/logs/submit.html">submitting log entries</a>
+            without time.
+        </change>
+        <change commit="08ee9b59" version="1127" date="2016-01-14" type="enhancement">
+            Allowed to search for <em>multiple</em> users that (not) found
+            a geocache.
+        </change>
+        <change commit="cb7d222b" version="" date="" type="bugfix">
+            Improved posting plaintext logs on OCPL sites.
+        </change>
+        <change commit="28825396" version="" date="" type="bugfix">
+            Enabled full 32-bit Unicode for submitting logs on some OC sites. 
+        </change>
+    </changes>
+</xml>

--- a/etc/changes.xml
+++ b/etc/changes.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+
+This is an incomplete list of changes in the OKAPI interface.
+Please add only changes which are relevant for client developers
+or site admins.
+
+New entries are inserted at the top with EMPTY version number
+and date. Run update_changes.php to insert the version numbers
+and dates.
+
+-->
+<changes>
+    <change commit="93cfc2d9" version="1237" date="2016-03-31" type="enhancement">
+        New methods for &lt;a href="services/logs/images/add.html"&gt;adding&lt;/a&gt;,
+        &lt;a href="services/logs/images/edit.html"&gt;editing&lt;/a&gt; and
+        &lt;a href="services/logs/images/delete.html"&gt;deleting&lt;/a&gt; log images.
+    </change>
+    <change commit="cf97cb2f" version="1200" date="2016-03-17" type="enhancement">
+        Consumer keys may be revoked by OC site admins.
+    </change>
+    <change commit="31061755" version="1194" date="2016-03-17" type="bugfix">
+        &lt;a href="services/oauth/authorize.html"&gt;services/oauth/authorize&lt;/a&gt;
+        will no longer delete Opencaching.DE cookies when called with parameter
+        &lt;i&gt;interactivity=confirm_user&lt;/i&gt;.
+    </change>
+    <change commit="3dbe4760" version="1184" date="2016-03-14" type="enhancement">
+        OCDE geocache log entries with and without time are more reasonably
+        ordered. Developers are recommended to keep the order as returned by
+        OKAPI instead of ordering by the log date.
+    </change>
+    <change commit="a711d95c" version="1183" date="2016-03-13" type="enhancement">
+        Registration date of users can be retrieved.
+    </change>
+    <change commit="28f4cefd" version="1177" date="2016-03-12" type="enhancement">
+        Added the 'needs maintenance' flag to log entries and geocaches.
+    </change>
+    <change commit="58474a4d" version="1169" date="2016-03-11" type="enhancement">
+        Added Romanian translation.
+    </change>
+    <change commit="f24c7ac2" version="1154" date="2016-03-04" type="enhancement">
+        For caches with the mark 'listing is outdated' (available only on some
+        OC sites), a corresponding message is prepended to the description
+        field. DO NOT rely on this message being there or having a certain
+        content. It may be changed in the future.
+    </change>
+    <change commit="a9a2a042" version="1145" date="2016-02-10" type="enhancement">
+        The home location of users can be queried, if given in the user's
+        profile (OAuth level 3).
+    </change>
+    <change commit="54ad2cf8" version="1133" date="2016-01-16" type="enhancement">
+        The URL of the OC site's registration page can be retrieved via
+        &lt;a href="services/apisrv/installation.html"&gt;apisrv/installation&lt;/a&gt;.
+    </change>
+    <change commit="834fdd9b" version="1132" date="2016-01-15" type="bugfix">
+        Restored the Opencaching.com namespace definition for GPX.
+    </change>
+    <change commit="24a12af0" version="1131" date="2016-01-15" type="docs">
+        Clarified the documentation on
+        &lt;a href="services/logs/submit.html"&gt;submitting log entries&lt;/a&gt;
+        without time.
+    </change>
+    <change commit="08ee9b59" version="1127" date="2016-01-14" type="enhancement">
+        Allowed to search for &lt;em&gt;multiple&lt;/em&gt; users that (not)
+        found a geocache.
+    </change>
+</changes>

--- a/etc/changes.xml
+++ b/etc/changes.xml
@@ -11,144 +11,144 @@
    
     -->
     <changes>
-        <change commit="93cfc2d9" version="1237" date="2016-03-31 13:03" type="enhancement">
+        <change commit="93cfc2d9" version="1237" time="2016-03-31T13:03:56+0200" type="enhancement">
             New methods for <a href="services/logs/images/add.html">adding</a>,
             <a href="services/logs/images/edit.html">editing</a> and
             <a href="services/logs/images/delete.html">deleting</a> log images.
         </change>
-        <change commit="cf97cb2f" version="1200" date="2016-03-17 18:03" type="enhancement">
+        <change commit="cf97cb2f" version="1200" time="2016-03-17T18:03:29+0100" type="enhancement">
             Consumer keys may be revoked by OC site admins.
         </change>
-        <change commit="31061755" version="1194" date="2016-03-17 15:03" type="bugfix">
+        <change commit="31061755" version="1194" time="2016-03-17T15:03:51+0100" type="bugfix">
             <a href="services/oauth/authorize.html">services/oauth/authorize</a>
             will no longer delete Opencaching.DE cookies when called with parameter
             <i>interactivity=confirm_user</i>.
         </change>
-        <change commit="3dbe4760" version="1184" date="2016-03-14 23:03" type="enhancement">
+        <change commit="3dbe4760" version="1184" time="2016-03-14T23:03:29+0100" type="enhancement">
             OCDE geocache log entries with and without time are more reasonably
             ordered. Developers are <b>recommended</b> to keep the order as returned by
             OKAPI instead of ordering by the log date.
         </change>
-        <change commit="a711d95c" version="1183" date="2016-03-13 22:03" type="enhancement">
+        <change commit="a711d95c" version="1183" time="2016-03-13T22:03:52+0100" type="enhancement">
             The registration date of users can be retrieved.
         </change>
-        <change commit="28f4cefd" version="1177" date="2016-03-12 17:03" type="enhancement">
+        <change commit="28f4cefd" version="1177" time="2016-03-12T17:03:42+0100" type="enhancement">
             Added the 'needs maintenance' flag to log entries and geocaches.
             The <em>needs_maintenance</em> option of
             <a href="services/logs/submit.html">services/logs/submit</a> has
             been <b>deprecated</b>; use <em>needs_maintenance2</em> instead.
         </change>
-        <change commit="58474a4d" version="1169" date="2016-03-11 21:03" type="enhancement">
+        <change commit="58474a4d" version="1169" time="2016-03-11T21:03:35+0100" type="enhancement">
             Added Romanian translation.
         </change>
-        <change commit="f24c7ac2" version="1154" date="2016-03-04 20:03" type="enhancement">
+        <change commit="f24c7ac2" version="1154" time="2016-03-04T20:03:23+0100" type="enhancement">
             For caches with the mark 'listing is outdated' (available only on some
             OC sites), a corresponding message is prepended to the description
             field. DO NOT rely on this message being there or having a certain
             content. It may change in the future.
         </change>
-        <change commit="a9a2a042" version="1145" date="2016-02-10 19:02" type="enhancement">
+        <change commit="a9a2a042" version="1145" time="2016-02-10T19:02:58+0100" type="enhancement">
             The home location of users can be queried, if given in the user's
             profile (requires OAuth level 3).
         </change>
-        <change commit="54ad2cf8" version="1133" date="2016-01-16 14:01" type="enhancement">
+        <change commit="54ad2cf8" version="1133" time="2016-01-16T14:01:05+0100" type="enhancement">
             The URL of the OC site's registration page can be retrieved via
             <a href="services/apisrv/installation.html">apisrv/installation</a>.
         </change>
-        <change commit="834fdd9b" version="1132" date="2016-01-15 22:01" type="bugfix">
+        <change commit="834fdd9b" version="1132" time="2016-01-15T22:01:00+0100" type="bugfix">
             Restored the OpenCaching.com namespace definition for GPX.
         </change>
-        <change commit="24a12af0" version="1131" date="2016-01-15 21:01" type="docs">
+        <change commit="24a12af0" version="1131" time="2016-01-15T21:01:17+0100" type="docs">
             Added an <b>advice</b> to the documentation on how to
             <a href="services/logs/submit.html">submit log entries</a>
             without time.
         </change>
-        <change commit="08ee9b59" version="1127" date="2016-01-14 16:01" type="enhancement">
+        <change commit="08ee9b59" version="1127" time="2016-01-14T16:01:11+0100" type="enhancement">
             Allowed to search for <em>multiple</em> users that (not) found
             a geocache.
         </change>
-        <change commit="cb7d222b" version="1126" date="2016-01-07 23:01" type="enhancement">
+        <change commit="cb7d222b" version="1126" time="2016-01-07T23:01:51+0100" type="enhancement">
             Improved posting plaintext logs on OCPL sites.
         </change>
-        <change commit="28825396" version="1125" date="2015-12-22 19:12" type="enhancement">
+        <change commit="28825396" version="1125" time="2015-12-22T19:12:16+0100" type="enhancement">
             Enabled full 32-bit Unicode for submitting logs on some OC sites.
             Use <a href="services/apisrv/installation.html">services/apisrv/installation</a>
             to find out the <em>submit_charset</em> of an OC site.
         </change>
-        <change commit="b2d31a34" version="1119" date="2015-11-26 14:11" type="bugfix">
+        <change commit="b2d31a34" version="1119" time="2015-11-26T14:11:51+0100" type="bugfix">
             Solved rare problem when searching by distance or bbox
             (OKAPI crashed).
         </change>
-        <change commit="11003f0e" version="1117" date="2015-09-24 14:09" type="enhancement">
+        <change commit="11003f0e" version="1117" time="2015-09-24T14:09:19+0200" type="enhancement">
             Added the new <em>ignored_status</em> search option which allows
             to search for caches ignored by the user. This replaces the
             <em>exclude_ignored</em> option, which has been <b>deprecated</b>.
         </change>
-        <change commit="ad4f2b13" version="1115" date="2015-09-20 13:09" type="docs">
+        <change commit="ad4f2b13" version="1115" time="2015-09-20T13:09:25+0200" type="docs">
             There is a new Opencaching.FR website, which is a local view of
             Opencaching.DE.
             Use <a href="http://www.opencaching.de/okapi">www.opencaching.de/okapi</a>
             to access it.
         </change>
-        <change commit="7622a486" version="1112" date="2015-09-09 20:09" type="enhancement">
+        <change commit="7622a486" version="1112" time="2015-09-09T20:09:38+0200" type="enhancement">
             Quicker refreshing of map tiles after geocache name changes.
         </change>
-        <change commit="3cd62446" version="1101" date="2015-08-01 10:08" type="bugfix">
+        <change commit="3cd62446" version="1101" time="2015-08-01T10:08:54+0200" type="bugfix">
             Return an HTTP 400 when "negative" dates are passed to
             <a href="services/logs/submit.html">services/logs/submit</a>.
         </change>
-        <change commit="aef3c045" version="1100" date="2015-08-01 10:08" type="bugfix">
+        <change commit="aef3c045" version="1100" time="2015-08-01T10:08:43+0200" type="bugfix">
             Improved uuid creation for submitted logs.
         </change>
-        <change commit="4b08db67" version="1097" date="2015-08-01 01:08" type="enhancement">
+        <change commit="4b08db67" version="1097" time="2015-08-01T01:08:26+0200" type="enhancement">
             <a href='services/caches/map/tile.html'>services/caches/map/tile</a>
             now is available to chosen consumers (closed BETA).
         </change>
-        <change commit="edd77fc5" version="1095" date="2015-07-31 22:07" type="bugfix">
+        <change commit="edd77fc5" version="1095" time="2015-07-31T22:07:11+0200" type="bugfix">
             Pipe chars (|) in user names are treated as errors.
         </change>
-        <change commit="0dcf3384" version="1092" date="2015-07-28 15:07" type="enhancement">
+        <change commit="0dcf3384" version="1092" time="2015-07-28T15:07:16+0200" type="enhancement">
             The user's last-login date on the OC site is updated when running
             OAuth level 3 methods.
         </change>
-        <change commit="2148472b" version="1089" date="2015-07-20 17:07" type="other">
+        <change commit="2148472b" version="1089" time="2015-07-20T17:07:21+0200" type="other">
             The OKAPI code repository has moved from Google Code to Github.
         </change>
-        <change commit="1280822d" version="1074" date="2015-06-29 09:06" type="enhancement">
+        <change commit="1280822d" version="1074" time="2015-06-29T09:06:21+0000" type="enhancement">
             When quering the <em>is_watched</em> state of a geocache or searching
             for watched caches, indirect watches via geocache lists are included.
             (Geocache lists so far are available only at OCDE and cannot be
             directly accessed via OKAPI.)
         </change>
-        <change commit="9f2c769f" version="1070" date="2015-03-29 10:03" type="other">
+        <change commit="9f2c769f" version="1070" time="2015-03-29T10:03:23+0000" type="other">
             Opencaching.org.UK has been removed from the list of OKAPI
             installations, because it is too outdated.
         </change>
-        <change commit="6c87331f" version="1069" date="2015-03-27 21:03" type="enhancement">
+        <change commit="6c87331f" version="1069" time="2015-03-27T21:03:23+0000" type="enhancement">
             The new <em>powertrail_only</em> option allows to search for caches
             that are part of a powertrail (on some OC nodes). This is a BETA
             feature, i.e. it may be changed or removed.
         </change>
-        <change commit="f31952a3" version="1065" date="2015-03-08 21:03" type="docs">
+        <change commit="f31952a3" version="1065" time="2015-03-08T21:03:05+0000" type="docs">
             Updated the <a href="introduction.html">Introduction page</a>,
             with additional <b>advices</b> on backward compatibility.
         </change>
-        <change commit="a78a2f2a" version="1062" date="2015-03-08 20:03" type="enhancement">
+        <change commit="a78a2f2a" version="1062" time="2015-03-08T20:03:23+0000" type="enhancement">
             Interprete intervals of
             <a href="services/caches/search/bbox.html">services/caches/search/bbox</a>
             as greater-side-open instead of closed.
         </change>
-        <change commit="f63ccbc0" version="1061" date="2015-03-02 13:03" type="bugfix">
+        <change commit="f63ccbc0" version="1061" time="2015-03-02T13:03:05+0000" type="bugfix">
             Added missing oauth_token parameter to error redirect.
         </change>
-        <change commit="859167c5" version="1059" date="2015-01-18 00:01" type="enhancement">
+        <change commit="859167c5" version="1059" time="2015-01-18T00:01:30+0000" type="enhancement">
             Added "stealth required" attribute (A74).
         </change>
-        <change commit="36e404d1" version="1056" date="2015-01-09 15:01" type="bugfix">
+        <change commit="36e404d1" version="1056" time="2015-01-09T15:01:29+0000" type="bugfix">
             Corrected the attribute assignments of OC.NL 'lost place' (A30 -> A29)
             and geodetic point (A2).
         </change>
-        <change commit="95c3dde2" version="1053" date="2014-11-30 02:11" type="docs">
+        <change commit="95c3dde2" version="1053" time="2014-11-30T02:11:12+0000" type="docs">
             OKAPI has been deployed to <a href="http://opencaching.ro/okapi">Opencaching.RO</a>.
         </change>
     </changes>

--- a/etc/changes.xml
+++ b/etc/changes.xml
@@ -11,144 +11,144 @@
    
     -->
     <changes>
-        <change commit="93cfc2d9" version="1237" date="2016-03-31" type="enhancement">
+        <change commit="93cfc2d9" version="1237" date="2016-03-31 13:03" type="enhancement">
             New methods for <a href="services/logs/images/add.html">adding</a>,
             <a href="services/logs/images/edit.html">editing</a> and
             <a href="services/logs/images/delete.html">deleting</a> log images.
         </change>
-        <change commit="cf97cb2f" version="1200" date="2016-03-17" type="enhancement">
+        <change commit="cf97cb2f" version="1200" date="2016-03-17 18:03" type="enhancement">
             Consumer keys may be revoked by OC site admins.
         </change>
-        <change commit="31061755" version="1194" date="2016-03-17" type="bugfix">
+        <change commit="31061755" version="1194" date="2016-03-17 15:03" type="bugfix">
             <a href="services/oauth/authorize.html">services/oauth/authorize</a>
             will no longer delete Opencaching.DE cookies when called with parameter
             <i>interactivity=confirm_user</i>.
         </change>
-        <change commit="3dbe4760" version="1184" date="2016-03-14" type="enhancement">
+        <change commit="3dbe4760" version="1184" date="2016-03-14 23:03" type="enhancement">
             OCDE geocache log entries with and without time are more reasonably
             ordered. Developers are <b>recommended</b> to keep the order as returned by
             OKAPI instead of ordering by the log date.
         </change>
-        <change commit="a711d95c" version="1183" date="2016-03-13" type="enhancement">
+        <change commit="a711d95c" version="1183" date="2016-03-13 22:03" type="enhancement">
             The registration date of users can be retrieved.
         </change>
-        <change commit="28f4cefd" version="1177" date="2016-03-12" type="enhancement">
+        <change commit="28f4cefd" version="1177" date="2016-03-12 17:03" type="enhancement">
             Added the 'needs maintenance' flag to log entries and geocaches.
             The <em>needs_maintenance</em> option of
             <a href="services/logs/submit.html">services/logs/submit</a> has
             been <b>deprecated</b>; use <em>needs_maintenance2</em> instead.
         </change>
-        <change commit="58474a4d" version="1169" date="2016-03-11" type="enhancement">
+        <change commit="58474a4d" version="1169" date="2016-03-11 21:03" type="enhancement">
             Added Romanian translation.
         </change>
-        <change commit="f24c7ac2" version="1154" date="2016-03-04" type="enhancement">
+        <change commit="f24c7ac2" version="1154" date="2016-03-04 20:03" type="enhancement">
             For caches with the mark 'listing is outdated' (available only on some
             OC sites), a corresponding message is prepended to the description
             field. DO NOT rely on this message being there or having a certain
             content. It may change in the future.
         </change>
-        <change commit="a9a2a042" version="1145" date="2016-02-10" type="enhancement">
+        <change commit="a9a2a042" version="1145" date="2016-02-10 19:02" type="enhancement">
             The home location of users can be queried, if given in the user's
             profile (requires OAuth level 3).
         </change>
-        <change commit="54ad2cf8" version="1133" date="2016-01-16" type="enhancement">
+        <change commit="54ad2cf8" version="1133" date="2016-01-16 14:01" type="enhancement">
             The URL of the OC site's registration page can be retrieved via
             <a href="services/apisrv/installation.html">apisrv/installation</a>.
         </change>
-        <change commit="834fdd9b" version="1132" date="2016-01-15" type="bugfix">
+        <change commit="834fdd9b" version="1132" date="2016-01-15 22:01" type="bugfix">
             Restored the OpenCaching.com namespace definition for GPX.
         </change>
-        <change commit="24a12af0" version="1131" date="2016-01-15" type="docs">
+        <change commit="24a12af0" version="1131" date="2016-01-15 21:01" type="docs">
             Added an <b>advice</b> to the documentation on how to
             <a href="services/logs/submit.html">submit log entries</a>
             without time.
         </change>
-        <change commit="08ee9b59" version="1127" date="2016-01-14" type="enhancement">
+        <change commit="08ee9b59" version="1127" date="2016-01-14 16:01" type="enhancement">
             Allowed to search for <em>multiple</em> users that (not) found
             a geocache.
         </change>
-        <change commit="cb7d222b" version="1126" date="2016-01-07" type="enhancement">
+        <change commit="cb7d222b" version="1126" date="2016-01-07 23:01" type="enhancement">
             Improved posting plaintext logs on OCPL sites.
         </change>
-        <change commit="28825396" version="1125" date="2015-12-22" type="enhancement">
+        <change commit="28825396" version="1125" date="2015-12-22 19:12" type="enhancement">
             Enabled full 32-bit Unicode for submitting logs on some OC sites.
             Use <a href="services/apisrv/installation.html">services/apisrv/installation</a>
             to find out the <em>submit_charset</em> of an OC site.
         </change>
-        <change commit="b2d31a34" version="1119" date="2015-11-26" type="bugfix">
+        <change commit="b2d31a34" version="1119" date="2015-11-26 14:11" type="bugfix">
             Solved rare problem when searching by distance or bbox
             (OKAPI crashed).
         </change>
-        <change commit="11003f0e" version="1117" date="2015-09-24" type="enhancement">
+        <change commit="11003f0e" version="1117" date="2015-09-24 14:09" type="enhancement">
             Added the new <em>ignored_status</em> search option which allows
             to search for caches ignored by the user. This replaces the
             <em>exclude_ignored</em> option, which has been <b>deprecated</b>.
         </change>
-        <change commit="ad4f2b13" version="1115" date="2015-09-20" type="docs">
+        <change commit="ad4f2b13" version="1115" date="2015-09-20 13:09" type="docs">
             There is a new Opencaching.FR website, which is a local view of
             Opencaching.DE.
             Use <a href="http://www.opencaching.de/okapi">www.opencaching.de/okapi</a>
             to access it.
         </change>
-        <change commit="7622a486" version="1112" date="2015-09-09" type="enhancement">
+        <change commit="7622a486" version="1112" date="2015-09-09 20:09" type="enhancement">
             Quicker refreshing of map tiles after geocache name changes.
         </change>
-        <change commit="3cd62446" version="1101" date="2015-08-01" type="bugfix">
+        <change commit="3cd62446" version="1101" date="2015-08-01 10:08" type="bugfix">
             Return an HTTP 400 when "negative" dates are passed to
             <a href="services/logs/submit.html">services/logs/submit</a>.
         </change>
-        <change commit="aef3c045" version="1100" date="2015-08-01" type="bugfix">
+        <change commit="aef3c045" version="1100" date="2015-08-01 10:08" type="bugfix">
             Improved uuid creation for submitted logs.
         </change>
-        <change commit="4b08db67" version="1097" date="2015-08-01" type="enhancement">
+        <change commit="4b08db67" version="1097" date="2015-08-01 01:08" type="enhancement">
             <a href='services/caches/map/tile.html'>services/caches/map/tile</a>
             now is available to chosen consumers (closed BETA).
         </change>
-        <change commit="edd77fc5" version="1095" date="2015-07-31" type="bugfix">
+        <change commit="edd77fc5" version="1095" date="2015-07-31 22:07" type="bugfix">
             Pipe chars (|) in user names are treated as errors.
         </change>
-        <change commit="0dcf3384" version="1092" date="2015-07-28" type="enhancement">
+        <change commit="0dcf3384" version="1092" date="2015-07-28 15:07" type="enhancement">
             The user's last-login date on the OC site is updated when running
             OAuth level 3 methods.
         </change>
-        <change commit="2148472b" version="1089" date="2015-07-20" type="other">
+        <change commit="2148472b" version="1089" date="2015-07-20 17:07" type="other">
             The OKAPI code repository has moved from Google Code to Github.
         </change>
-        <change commit="1280822d" version="1074" date="2015-06-29" type="enhancement">
+        <change commit="1280822d" version="1074" date="2015-06-29 09:06" type="enhancement">
             When quering the <em>is_watched</em> state of a geocache or searching
             for watched caches, indirect watches via geocache lists are included.
             (Geocache lists so far are available only at OCDE and cannot be
             directly accessed via OKAPI.)
         </change>
-        <change commit="9f2c769f" version="1070" date="2015-03-29" type="other">
+        <change commit="9f2c769f" version="1070" date="2015-03-29 10:03" type="other">
             Opencaching.org.UK has been removed from the list of OKAPI
             installations, because it is too outdated.
         </change>
-        <change commit="6c87331f" version="1069" date="2015-03-27" type="enhancement">
+        <change commit="6c87331f" version="1069" date="2015-03-27 21:03" type="enhancement">
             The new <em>powertrail_only</em> option allows to search for caches
             that are part of a powertrail (on some OC nodes). This is a BETA
             feature, i.e. it may be changed or removed.
         </change>
-        <change commit="f31952a3" version="1065" date="2015-03-08" type="docs">
+        <change commit="f31952a3" version="1065" date="2015-03-08 21:03" type="docs">
             Updated the <a href="introduction.html">Introduction page</a>,
             with additional <b>advices</b> on backward compatibility.
         </change>
-        <change commit="a78a2f2a" version="1062" date="2015-03-08" type="enhancement">
+        <change commit="a78a2f2a" version="1062" date="2015-03-08 20:03" type="enhancement">
             Interprete intervals of
             <a href="services/caches/search/bbox.html">services/caches/search/bbox</a>
             as greater-side-open instead of closed.
         </change>
-        <change commit="f63ccbc0" version="1061" date="2015-03-02" type="bugfix">
+        <change commit="f63ccbc0" version="1061" date="2015-03-02 13:03" type="bugfix">
             Added missing oauth_token parameter to error redirect.
         </change>
-        <change commit="859167c5" version="1059" date="2015-01-18" type="enhancement">
+        <change commit="859167c5" version="1059" date="2015-01-18 00:01" type="enhancement">
             Added "stealth required" attribute (A74).
         </change>
-        <change commit="36e404d1" version="1056" date="2015-01-09" type="bugfix">
+        <change commit="36e404d1" version="1056" date="2015-01-09 15:01" type="bugfix">
             Corrected the attribute assignments of OC.NL 'lost place' (A30 -> A29)
             and geodetic point (A2).
         </change>
-        <change commit="95c3dde2" version="1053" date="2014-11-30" type="docs">
+        <change commit="95c3dde2" version="1053" date="2014-11-30 02:11" type="docs">
             OKAPI has been deployed to <a href="http://opencaching.ro/okapi">Opencaching.RO</a>.
         </change>
     </changes>

--- a/etc/changes.xml
+++ b/etc/changes.xml
@@ -33,6 +33,9 @@
         </change>
         <change commit="28f4cefd" version="1177" date="2016-03-12" type="enhancement">
             Added the 'needs maintenance' flag to log entries and geocaches.
+            The <em>needs_maintenance</em> option of
+            <a href="services/logs/submit.html">services/logs/submit</a> has
+            been deprecated; use <em>needs_maintenance2</em> instead.
         </change>
         <change commit="58474a4d" version="1169" date="2016-03-11" type="enhancement">
             Added Romanian translation.
@@ -41,7 +44,7 @@
             For caches with the mark 'listing is outdated' (available only on some
             OC sites), a corresponding message is prepended to the description
             field. DO NOT rely on this message being there or having a certain
-            content. It may be changed in the future.
+            content. It may change in the future.
         </change>
         <change commit="a9a2a042" version="1145" date="2016-02-10" type="enhancement">
             The home location of users can be queried, if given in the user's
@@ -63,11 +66,88 @@
             Allowed to search for <em>multiple</em> users that (not) found
             a geocache.
         </change>
-        <change commit="cb7d222b" version="" date="" type="bugfix">
+        <change commit="cb7d222b" version="1126" date="2016-01-07" type="enhancement">
             Improved posting plaintext logs on OCPL sites.
         </change>
-        <change commit="28825396" version="" date="" type="bugfix">
-            Enabled full 32-bit Unicode for submitting logs on some OC sites. 
+        <change commit="28825396" version="1125" date="2015-12-22" type="enhancement">
+            Enabled full 32-bit Unicode for submitting logs on some OC sites.
+            Use <a href="services/apisrv/installation.html">services/apisrv/installation</a>
+            to find out the <em>submit_charset</em> of an OC site.
+        </change>
+        <change commit="b2d31a34" version="1119" date="2015-11-26" type="bugfix">
+            Solved rare problem when searching by distance or bbox
+            (OKAPI crashed).
+        </change>
+        <change commit="11003f0e" version="1117" date="2015-09-24" type="enhancement">
+            Added the new <em>ignored_status</em> search option which allows
+            to search for caches ignored by the user. This replaces the
+            <em>exclude_ignored</em> option, which has been deprecated.
+        </change>
+        <change commit="ad4f2b13" version="1115" date="2015-09-20" type="docs">
+            There is a new Opencaching.FR website, which is a local view of
+            Opencaching.DE.
+            Use <a href="http://www.opencaching.de/okapi">www.opencaching.de/okapi</a>
+            to access it.
+        </change>
+        <change commit="7622a486" version="1112" date="2015-09-09" type="enhancement">
+            Quicker refreshing of map tiles after geocache name changes.
+        </change>
+        <change commit="3cd62446" version="1101" date="2015-08-01" type="bugfix">
+            Return an HTTP 400 when "negative" dates are passed to
+            <a href="services/logs/submit.html">services/logs/submit</a>.
+        </change>
+        <change commit="aef3c045" version="1100" date="2015-08-01" type="bugfix">
+            Improved uuid creation for submitted logs.
+        </change>
+        <change commit="4b08db67" version="1097" date="2015-08-01" type="enhancement">
+            <a href='services/caches/map/tile.html'>services/caches/map/tile</a>
+            now is available to chosen consumers (closed BETA).
+        </change>
+        <change commit="edd77fc5" version="1095" date="2015-07-31" type="bugfix">
+            Pipe chars (|) in user names are treated as errors.
+        </change>
+        <change commit="0dcf3384" version="1092" date="2015-07-28" type="enhancement">
+            The user's last-login date on the OC site is updated when running
+            OAuth level 3 methods.
+        </change>
+        <change commit="2148472b" version="1089" date="2015-07-20" type="other">
+            The OKAPI code repository has moved from Google Code to Github.
+        </change>
+        <change commit="1280822d" version="1074" date="2015-06-29" type="enhancement">
+            When quering the <em>is_watched</em> state of a geocache or searching
+            for watched caches, indirect watches via geocache lists are included.
+            (Geocache lists so far are available only at OCDE and cannot be
+            directly accessed via OKAPI.)
+        </change>
+        <change commit="9f2c769f" version="1070" date="2015-03-29" type="other">
+            Opencaching.org.UK has been removed from the list of OKAPI
+            installations, because it is too outdated.
+        </change>
+        <change commit="6c87331f" version="1069" date="2015-03-27" type="other">
+            The new <em>powertrail_only</em> option allows to search for caches
+            that are part of a powertrail (on some OC nodes). This is a BETA
+            feature, i.e. it may be changed or removed.
+        </change>
+        <change commit="f31952a3" version="1065" date="2015-03-08" type="docs">
+            Updated the <a href="introduction.html">Introduction page</a>.
+        </change>
+        <change commit="a78a2f2a" version="1062" date="2015-03-08" type="enhancement">
+            Interprete intervals of
+            <a href="services/caches/search/bbox.html">services/caches/search/bbox</a>
+            as greater-side-open instead of closed.
+        </change>
+        <change commit="f63ccbc0" version="1061" date="2015-03-02" type="bugfix">
+            Added missing oauth_token parameter to error redirect.
+        </change>
+        <change commit="859167c5" version="1059" date="2015-01-18" type="enhancement">
+            Added "stealth required" attribute (A74).
+        </change>
+        <change commit="36e404d1" version="1056" date="2015-01-09" type="bugfix">
+            Corrected the attribute assignments of OC.NL 'lost place' (A30 -> A29)
+            and geodetic point (A2).
+        </change>
+        <change commit="95c3dde2" version="1053" date="2014-11-30" type="docs">
+            OKAPI has been deployed to <a href="http://opencaching.ro/okapi">Opencaching.RO</a>.
         </change>
     </changes>
 </xml>

--- a/etc/changes.xml
+++ b/etc/changes.xml
@@ -3,10 +3,11 @@
 
     This is an incomplete list of changes in the OKAPI interface.
     Please add only changes which are relevant for client developers
-    or site admins.
+    or site admins. If you are not sure if a change is stable, consider
+    to wait some time before you add it here.
 
     New entries are inserted at the top with EMPTY version number and date.
-    Run update_changes.php to insert the version numbers and dates.
+    Then run update_changes.php to insert the version numbers and dates.
    
     -->
     <changes>
@@ -123,7 +124,7 @@
             Opencaching.org.UK has been removed from the list of OKAPI
             installations, because it is too outdated.
         </change>
-        <change commit="6c87331f" version="1069" date="2015-03-27" type="other">
+        <change commit="6c87331f" version="1069" date="2015-03-27" type="enhancement">
             The new <em>powertrail_only</em> option allows to search for caches
             that are part of a powertrail (on some OC nodes). This is a BETA
             feature, i.e. it may be changed or removed.

--- a/etc/changes.xml
+++ b/etc/changes.xml
@@ -25,7 +25,7 @@
         </change>
         <change commit="3dbe4760" version="1184" date="2016-03-14" type="enhancement">
             OCDE geocache log entries with and without time are more reasonably
-            ordered. Developers are recommended to keep the order as returned by
+            ordered. Developers are <b>recommended</b> to keep the order as returned by
             OKAPI instead of ordering by the log date.
         </change>
         <change commit="a711d95c" version="1183" date="2016-03-13" type="enhancement">
@@ -35,7 +35,7 @@
             Added the 'needs maintenance' flag to log entries and geocaches.
             The <em>needs_maintenance</em> option of
             <a href="services/logs/submit.html">services/logs/submit</a> has
-            been deprecated; use <em>needs_maintenance2</em> instead.
+            been <b>deprecated</b>; use <em>needs_maintenance2</em> instead.
         </change>
         <change commit="58474a4d" version="1169" date="2016-03-11" type="enhancement">
             Added Romanian translation.
@@ -58,8 +58,8 @@
             Restored the OpenCaching.com namespace definition for GPX.
         </change>
         <change commit="24a12af0" version="1131" date="2016-01-15" type="docs">
-            Clarified the documentation on
-            <a href="services/logs/submit.html">submitting log entries</a>
+            Added an <b>advice</b> to the documentation on how to
+            <a href="services/logs/submit.html">submit log entries</a>
             without time.
         </change>
         <change commit="08ee9b59" version="1127" date="2016-01-14" type="enhancement">
@@ -81,7 +81,7 @@
         <change commit="11003f0e" version="1117" date="2015-09-24" type="enhancement">
             Added the new <em>ignored_status</em> search option which allows
             to search for caches ignored by the user. This replaces the
-            <em>exclude_ignored</em> option, which has been deprecated.
+            <em>exclude_ignored</em> option, which has been <b>deprecated</b>.
         </change>
         <change commit="ad4f2b13" version="1115" date="2015-09-20" type="docs">
             There is a new Opencaching.FR website, which is a local view of
@@ -129,7 +129,8 @@
             feature, i.e. it may be changed or removed.
         </change>
         <change commit="f31952a3" version="1065" date="2015-03-08" type="docs">
-            Updated the <a href="introduction.html">Introduction page</a>.
+            Updated the <a href="introduction.html">Introduction page</a>,
+            with additional <b>advices</b> on backward compatibility.
         </change>
         <change commit="a78a2f2a" version="1062" date="2015-03-08" type="enhancement">
             Interprete intervals of

--- a/etc/update_changes.php
+++ b/etc/update_changes.php
@@ -22,12 +22,14 @@ foreach ($gitlog as $line)
 
         case 'committer':
             $time = $tokens[count($tokens) - 2];
+            $timezone = $tokens[count($tokens) - 1];
             break;
 
         case '':
             if ($time) {
                 $commits[$commit] = array(
                     'time' => $time,
+                    'timezone' => $timezone,
                     'position' => count($commits)
                 );
                 $time = false;
@@ -50,30 +52,32 @@ foreach ($changes as &$line)
     if (preg_match('/^\s*<change /', $line))
     {
         if (preg_match(
-            '/^\s*<change\s+commit="(.*?)"\s+version="(.*?)"\s+date="(.*?)"([^>]*)>$/',
+            '/^\s*<change\s+commit="(.+?)"\s+version="(.*?)"\s+time="(.*?)"\s+type="(.+?)"\s*>$/',
             $line,
             $matches
         )) {
-            list(, $commit, $version, $date, $rest) = $matches;
+            list(, $commit, $version, $time, $type) = $matches;
 
             if (strlen($commit) != 8)
                 die("error: commit ID $commit is not 8 chars long\n");
             if (!isset($commits[$commit]))
                 die("error: didn't find commit ID $commit in OKAPI git repo\n");
+            if (!in_array($type, array('enhancement', 'bugfix', 'docs', 'other')))
+                die("error: unknown type '$type' for commit $commit\n");
 
             $repo_version = $OKAPI_GIT_VERSION_BASE + count($commits) - $commits[$commit]['position'];
-            $wrong_version = ($version != '' && $version != $repo_version);
+            $repo_time = date('Y-m-d\TH:m:s', $commits[$commit]['time']) . $commits[$commit]['timezone'];
 
-            if ($version == '' || $wrong_version) {
+            if ($version != $repo_version) {
                 $version = $repo_version;
                 echo $commit . ' version = ' . $version . "\n";
             }
-            if ($date == '' || $wrong_version) {
-                $date = date('Y-m-d H:m', $commits[$commit]['time']);
-                echo $commit . ' date = ' . $date . "\n";
+            if ($time != $repo_time) {
+                $time = $repo_time;
+                echo $commit . ' time = ' . $time . "\n";
             }
 
-            $line = '        <change commit="'.$commit.'" version="'.$version.'" date="'.$date.'"'.$rest.">\n";
+            $line = '        <change commit="'.$commit.'" version="'.$version.'" time="'.$time.'" type="'.$type."\">\n";
         }
         else
         {

--- a/etc/update_changes.php
+++ b/etc/update_changes.php
@@ -40,10 +40,10 @@ $OKAPI_GIT_VERSION_BASE = 318;
 
 # test for well-formed XML
 # TODO: verify XML scheme
-simplexml_load_file('changes.xml');
+simplexml_load_file(__DIR__ . '/changes.xml');
 
 # SimpleXML iterators are read-only, so we process the plain text file.
-$changes = file('changes.xml');
+$changes = file(__DIR__ . '/changes.xml');
 
 foreach ($changes as &$line)
 {
@@ -61,11 +61,14 @@ foreach ($changes as &$line)
             if (!isset($commits[$commit]))
                 die("error: didn't find commit ID $commit in OKAPI git repo\n");
 
-            if ($version == '') {
-                $version = $OKAPI_GIT_VERSION_BASE + count($commits) - $commits[$commit]['position'];
+            $repo_version = $OKAPI_GIT_VERSION_BASE + count($commits) - $commits[$commit]['position'];
+            $wrong_version = ($version != '' && $version != $repo_version);
+
+            if ($version == '' || $wrong_version) {
+                $version = $repo_version;
                 echo $commit . ' version = ' . $version . "\n";
             }
-            if ($date == '') {
+            if ($date == '' || $wrong_version) {
                 $date = date('Y-m-d', $commits[$commit]['time']);
                 echo $commit . ' date = ' . $date . "\n";
             }
@@ -79,4 +82,4 @@ foreach ($changes as &$line)
     }
 }
 
-file_put_contents('changes.xml', $changes);
+file_put_contents(__DIR__ . '/changes.xml', $changes);

--- a/etc/update_changes.php
+++ b/etc/update_changes.php
@@ -1,0 +1,82 @@
+<?php
+# This script MUST be run after each update of changes.xml.
+# It inserts version numbers and dates.
+
+exec('git --git-dir='.__DIR__.'/../.git log --pretty=raw', $gitlog);
+if (!$gitlog)
+    die("error: could not run git\n");
+
+# parse the git log; build an array of all commits
+
+$commits = array();
+$time = false;
+
+foreach ($gitlog as $line)
+{
+    $tokens = explode(' ', $line);
+    switch ($tokens[0])
+    {
+        case 'commit':
+            $commit = substr($tokens[1], 0, 8);
+            break;
+
+        case 'committer':
+            $time = $tokens[count($tokens) - 2];
+            break;
+
+        case '':
+            if ($time) {
+                $commits[$commit] = array(
+                    'time' => $time,
+                    'position' => count($commits)
+                );
+                $time = false;
+            }
+            break;
+    }
+}
+
+$OKAPI_GIT_VERSION_BASE = 318;
+
+# test for well-formed XML
+# TODO: verify XML scheme
+simplexml_load_file('changes.xml');
+
+# SimpleXML iterators are read-only, so we process the plain text file.
+$changes = file('changes.xml');
+
+foreach ($changes as &$line)
+{
+    if (preg_match('/^\s*<change /', $line))
+    {
+        if (preg_match(
+            '/^\s*<change\s+commit="(.*?)"\s+version="(.*?)"\s+date="(.*?)"([^>]*)>$/',
+            $line,
+            $matches
+        )) {
+            list(, $commit, $version, $date, $rest) = $matches;
+
+            if (strlen($commit) != 8)
+                die("error: commit ID $commit is not 8 chars long\n");
+            if (!isset($commits[$commit]))
+                die("error: didn't find commit ID $commit in OKAPI git repo\n");
+
+            if ($version == '') {
+                $version = $OKAPI_GIT_VERSION_BASE + count($commits) - $commits[$commit]['position'];
+                echo $commit . ' version = ' . $version . "\n";
+            }
+            if ($date == '') {
+                $date = date('Y-m-d', $commits[$commit]['time']);
+                echo $commit . ' date = ' . $date . "\n";
+            }
+
+            $line = '    <change commit="'.$commit.'" version="'.$version.'" date="'.$date.'"'.$rest.">\n";
+        }
+        else
+        {
+            die("error: unexpected <change> line format:\n$line\n");
+        }
+    }
+}
+
+file_put_contents('changes.xml', $changes);

--- a/etc/update_changes.php
+++ b/etc/update_changes.php
@@ -70,7 +70,7 @@ foreach ($changes as &$line)
                 echo $commit . ' date = ' . $date . "\n";
             }
 
-            $line = '    <change commit="'.$commit.'" version="'.$version.'" date="'.$date.'"'.$rest.">\n";
+            $line = '        <change commit="'.$commit.'" version="'.$version.'" date="'.$date.'"'.$rest.">\n";
         }
         else
         {

--- a/etc/update_changes.php
+++ b/etc/update_changes.php
@@ -69,7 +69,7 @@ foreach ($changes as &$line)
                 echo $commit . ' version = ' . $version . "\n";
             }
             if ($date == '' || $wrong_version) {
-                $date = date('Y-m-d', $commits[$commit]['time']);
+                $date = date('Y-m-d H:m', $commits[$commit]['time']);
                 echo $commit . ' date = ' . $date . "\n";
             }
 

--- a/okapi/static/common.css
+++ b/okapi/static/common.css
@@ -18,6 +18,10 @@ body.api { background: #f5f1eb; }
 .signup input.text { border: 1px solid #aaa; padding: 3px 4px 2px 4px; width: 300px }
 .signup .button { margin-top: 10px; padding: 3px 12px; background: #977; border: 2px solid #744; cursor: pointer; color: #fff; font-weight: bold; }
 
+.changelog { border: 1px solid #bbb; }
+.changelog th { background: #e1d7d8; }
+.changelog td { background: #eee9e9; padding: 8px 16px; }
+
 .apimenu { vertical-align: top; width: 225px; font-size: 15px; padding: 0px 20px 0 32px; }
 .apimenu .revision { float: right; font-size: 11px; color: #888; position: relative; top: -30px; }
 .apimenu a { color: #804937; text-decoration: none; }

--- a/okapi/static/common.css
+++ b/okapi/static/common.css
@@ -42,6 +42,8 @@ body.api { background: #f5f1eb; }
 .article ol { margin-bottom: 15px; margin-left: 35px; }
 .article li { margin: 6px 0; }
 .article li p { margin: 6px 0; }
+.article .floaticonlink { float: right; margin: 0 0 3em 1em; }
+.article .floaticonlink a { outline:0; }
 .article .issue-comments { font-size: 20px; font-weight: bold; }
 .article .issue-comments .notice { font-size: 11px; font-weight: normal; color: #888; padding-left: 10px; }
 .article .deprecated { color: #888; }

--- a/okapi/static/rss-feed.svg
+++ b/okapi/static/rss-feed.svg
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<!-- Source: https://commons.wikimedia.org/wiki/File:Rss-feed.svg -->
+<!-- License: public domain -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="256"
+   height="256"
+   id="svg2"
+   sodipodi:version="0.32"
+   inkscape:version="0.47 r22583"
+   sodipodi:docname="rss-feed.svg"
+   version="1.0"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient2555">
+      <stop
+         style="stop-color: rgb(255, 255, 255); stop-opacity: 1;"
+         offset="0"
+         id="stop2557" />
+      <stop
+         style="stop-color: rgb(255, 255, 255); stop-opacity: 0;"
+         offset="1"
+         id="stop2559" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2555"
+       id="linearGradient2449"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.5914583,0,0,0.5914584,210.0216,142.2324)"
+       x1="-344.15295"
+       y1="274.711"
+       x2="-395.84943"
+       y2="425.39993" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.35"
+     inkscape:cx="430.42472"
+     inkscape:cy="131.48311"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     inkscape:window-width="782"
+     inkscape:window-height="674"
+     inkscape:window-x="1"
+     inkscape:window-y="281"
+     showgrid="false"
+     inkscape:window-maximized="0" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:creator>
+        <dc:subject>
+          <rdf:Bag />
+        </dc:subject>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/publicdomain/" />
+        <dc:description />
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/publicdomain/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-373.642,-318.344)">
+    <rect
+       inkscape:export-ydpi="7.7063322"
+       inkscape:export-xdpi="7.7063322"
+       inkscape:export-filename="C:\Documents and Settings\Molumen\Desktop\path3511111.png"
+       transform="scale(-1,1)"
+       ry="35.487503"
+       rx="35.487503"
+       y="328.84921"
+       x="-619.14587"
+       height="234.98955"
+       width="235.00784"
+       id="rect1942"
+       style="fill:#e15a00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.87500000000000000;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.87500000000000000, 1.75000000000000000;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       inkscape:export-ydpi="7.7063322"
+       inkscape:export-xdpi="7.7063322"
+       inkscape:export-filename="C:\Documents and Settings\Molumen\Desktop\path3511111.png"
+       sodipodi:nodetypes="ccccsssc"
+       id="path1950"
+       d="M 557.05665,338.89518 L 446.22721,338.89518 C 416.89033,338.89518 393.27256,362.70492 393.27256,392.28025 L 393.27256,500.40761 C 394.22216,523.49366 397.87485,508.89915 404.82758,483.3329 C 412.90814,453.61975 439.22406,427.65003 471.27219,408.1872 C 495.73352,393.33195 523.11328,383.84595 572.95174,382.94353 C 601.21656,382.43177 598.72124,346.26062 557.05665,338.89518 z"
+       style="opacity:0.60747664;fill:url(#linearGradient2449);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.87500000000000000;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.87500000000000000, 1.75000000000000000;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       sodipodi:type="arc"
+       style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:12;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path5270"
+       sodipodi:cx="360.35715"
+       sodipodi:cy="200.64285"
+       sodipodi:rx="24.642859"
+       sodipodi:ry="23.928572"
+       d="m 385.00001,200.64285 c 0,13.21539 -11.03299,23.92857 -24.64286,23.92857 -13.60988,0 -24.64286,-10.71318 -24.64286,-23.92857 0,-13.21538 11.03298,-23.92857 24.64286,-23.92857 13.60987,0 24.64286,10.71319 24.64286,23.92857 z"
+       transform="matrix(0.8699574,0,0,0.8699574,135.15631,330.52863)" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 427.83482,455.05681 L 427.76203,424.78365 C 492.4681,428.1591 528.38081,474.45682 529.26224,526.72326 L 498.944,526.72326 C 498.44099,480.78249 467.20335,456.72804 427.83482,455.05681 z"
+       id="path5805"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 428.20143,404.57149 L 427.32264,373.81385 C 526.75104,378.43011 580.00028,450.58197 580.67143,526.72326 L 549.4744,526.28386 C 550.83932,477.58037 514.80871,406.01731 428.20143,404.57149 z"
+       id="path5807"
+       sodipodi:nodetypes="ccccc" />
+  </g>
+</svg>

--- a/okapi/urls.php
+++ b/okapi/urls.php
@@ -16,6 +16,7 @@ class OkapiUrls
         '^signup\.html$' => 'signup',
         '^examples\.html$' => 'examples',
         '^changelog\.html$' => 'changelog',
+        '^changelog_feed$' => 'changelog_feed',
         '^$' => 'index',
         '^apps/$' => 'apps/index',
         '^apps/authorize$' => 'apps/authorize',

--- a/okapi/urls.php
+++ b/okapi/urls.php
@@ -15,6 +15,7 @@ class OkapiUrls
         '^introduction\.html$' => 'introduction',
         '^signup\.html$' => 'signup',
         '^examples\.html$' => 'examples',
+        '^changelog\.html$' => 'changelog',
         '^$' => 'index',
         '^apps/$' => 'apps/index',
         '^apps/authorize$' => 'apps/authorize',

--- a/okapi/views/changelog.php
+++ b/okapi/views/changelog.php
@@ -5,7 +5,6 @@ namespace okapi\views\changelog;
 use Exception;
 use okapi\Okapi;
 use okapi\Settings;
-use okapi\Cache;
 use okapi\OkapiRequest;
 use okapi\OkapiHttpResponse;
 use okapi\views\menu\OkapiMenu;
@@ -15,89 +14,9 @@ class View
     public static function call()
     {
         require_once($GLOBALS['rootpath'].'okapi/views/menu.inc.php');
+        require_once($GLOBALS['rootpath'].'okapi/views/changelog_helper.inc.php');
 
-        $cache_key = 'changelog';
-        $cache_backup_key = 'changelog-backup';
-
-        $changes_xml = Cache::get($cache_key);
-        $changelog = null;
-
-        if (!$changes_xml)
-        {
-            # Download the current changelog.
-
-            try
-            {
-                $opts = array(
-                    'http' => array(
-                        'method' => "GET",
-                        'timeout' => 5.0
-                    )
-                );
-                $context = stream_context_create($opts);
-                $changes_xml = file_get_contents(
-                    # TODO: load from OKAPI repo
-                    'https://raw.githubusercontent.com/following5/okapi/feature/changelog/etc/changes.xml',
-                    false, $context
-                );
-                $changelog = simplexml_load_string($changes_xml);
-                if (!$changelog) {
-                    throw new ErrorException();
-                }
-                Cache::set($cache_key, $changes_xml, 3600);
-                Cache::set($cache_backup_key, $changes_xml, 3600*24*30);
-            }
-            catch (Exception $e)
-            {
-                # GitHub failed on us. User backup list, if available.
-
-                $changes_xml = Cache::get($cache_backup_key);
-                if ($changes_xml) {
-                    Cache::set($cache_key, $changes_xml, 3600*12);
-                }
-            }
-        }
-
-        if (!$changelog && $changes_xml) {
-            $changelog = simplexml_load_string($changes_xml);
-        }
-        # TODO: verify XML scheme
-
-        $unavailable_changes = array();
-        $available_changes = array();
-
-        if (!$changelog)
-        {
-            # We could not retreive the changelog from Github, and there was
-            # no backup key or it expired. Probably we are on a developer
-            # machine. The template will output some error message.
-        }
-        else
-        {
-            $commits = array();
-
-            foreach ($changelog->changes->change as $change) {
-                if ($change['version'] == '' || $change['date'] == '') {
-                    throw new Exception("Someone forgot to run update_changes.php.");
-                } elseif (isset($commits[(string)$change['commit']])) {
-                    throw new Exception("Duplicate commit " . $change['commit'] . " in changelog.");
-                } else {
-                    $change = array(
-                        'commit' => (string)$change['commit'],
-                        'version' => (string)$change['version'],
-                        'date' => (string)$change['date'],
-                        'type' => (string)$change['type'],
-                        'comment' => self::get_inner_xml($change),
-                    );
-                    if ($change['version'] > Okapi::$version_number) {
-                        $unavailable_changes[] = $change;
-                    } else {
-                        $available_changes[] = $change;
-                    }
-                    $commits[$change['commit']] = true;
-                }
-            }
-        }
+        $changelog = new Changelog();
 
         $vars = array(
             'menu' => OkapiMenu::get_menu_html("changelog.html"),
@@ -107,8 +26,8 @@ class View
             'okapi_rev' => Okapi::$version_number,
             'site_name' => Okapi::get_normalized_site_name(),
             'changes' => array(
-                'unavailable' => $unavailable_changes,
-                'available' => $available_changes
+                'unavailable' => $changelog->unavailable_changes,
+                'available' => $changelog->available_changes
             ),
         );
 
@@ -118,17 +37,5 @@ class View
         include 'changelog.tpl.php';
         $response->body = ob_get_clean();
         return $response;
-    }
-
-    private static function get_inner_xml($node)
-    {
-        /* Fetch as <some-node>content</some-node>, extract content. */
-
-        $s = $node->asXML();
-        $start = strpos($s, ">") + 1;
-        $length = strlen($s) - $start - (3 + strlen($node->getName()));
-        $s = substr($s, $start, $length);
-
-        return $s;
     }
 }

--- a/okapi/views/changelog.php
+++ b/okapi/views/changelog.php
@@ -19,14 +19,14 @@ class View
         # TODO: verify XML scheme
         $changes = simplexml_load_file('https://raw.githubusercontent.com/following5/okapi/feature/changelog/etc/changes.xml');
 
-        $installed_changes = array();
-        $uninstalled_changes = array();
+        $unavailable_changes = array();
+        $available_changes = array();
 
         foreach ($changes->change as $change) {
             if ($change['version'] > Okapi::$version_number)
-                $uninstalled_changes[] = $change;
+                $unavailable_changes[] = $change;
             else
-                $installed_changes[] = $change;
+                $available_changes[] = $change;
         }
 
         $vars = array(
@@ -37,8 +37,8 @@ class View
             'okapi_rev' => Okapi::$version_number,
             'site_name' => Okapi::get_normalized_site_name(),
             'changes' => array(
-                'uninstalled' => $uninstalled_changes,
-                'installed' => $installed_changes
+                'unavailable' => $unavailable_changes,
+                'available' => $available_changes
             ),
         );
 

--- a/okapi/views/changelog.php
+++ b/okapi/views/changelog.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace okapi\views\changelog;
+
+use Exception;
+use okapi\Okapi;
+use okapi\Settings;
+use okapi\OkapiRequest;
+use okapi\OkapiHttpResponse;
+use okapi\views\menu\OkapiMenu;
+
+class View
+{
+    public static function call()
+    {
+        require_once($GLOBALS['rootpath'].'okapi/views/menu.inc.php');
+
+        # TODO: load and cache from OKAPI repo
+        # TODO: verify XML scheme
+        $changes = simplexml_load_file('https://raw.githubusercontent.com/following5/okapi/feature/changelog/etc/changes.xml');
+
+        $installed_changes = array();
+        $uninstalled_changes = array();
+
+        foreach ($changes->change as $change) {
+            if ($change['version'] > Okapi::$version_number)
+                $uninstalled_changes[] = $change;
+            else
+                $installed_changes[] = $change;
+        }
+
+        $vars = array(
+            'menu' => OkapiMenu::get_menu_html("changelog.html"),
+            'okapi_base_url' => Settings::get('SITE_URL')."okapi/",
+            'site_url' => Settings::get('SITE_URL'),
+            'installations' => OkapiMenu::get_installations(),
+            'okapi_rev' => Okapi::$version_number,
+            'site_name' => Okapi::get_normalized_site_name(),
+            'changes' => array(
+                'uninstalled' => $uninstalled_changes,
+                'installed' => $installed_changes
+            ),
+        );
+
+        $response = new OkapiHttpResponse();
+        $response->content_type = "text/html; charset=utf-8";
+        ob_start();
+        include 'changelog.tpl.php';
+        $response->body = ob_get_clean();
+        return $response;
+    }
+}

--- a/okapi/views/changelog.tpl.php
+++ b/okapi/views/changelog.tpl.php
@@ -27,7 +27,12 @@
                     </td>
                     <td class='article'>
 
-                        <h1>Changes of the OKAPI interface or administration</h1>
+                        <h1>Changes to the OKAPI interface or administration</h1>
+
+                        <p>Changes to the interface are always backward compatible.
+                        You need not to update your applications after any change (but
+                        there may be new <em>recommendations</em> on how to use OKAPI
+                        methods).</p>
 
                         <?php
                         $br = '';
@@ -50,12 +55,21 @@
                                     <tr>
                                         <td><a href="https://github.com/opencaching/okapi/tree/<?= $change['commit'] ?>"><?= $change['version'] ?></a></td>
                                         <td><?= $change['date'] ?></td>
-                                        <td><?= ($change['type'] == 'bugfix' ? 'Fixed:' : '') . (string)$change ?></td>
+                                        <td><?= ($change['type'] == 'bugfix' ? 'Fixed:' : '') . $change['comment'] ?></td>
                                     </tr>
                                 <?php } ?>
                                 </table>
                             <?php } ?>
                         <?php } ?>
+
+                        <br />
+                        <p>This list shows only changes that are considered to be
+                        relevant for developers and site admins. Please consult the
+                        <a href="https://github.com/opencaching/okapi/commits/master">Git log</a>
+                        for a complete history, including older changes.</p>
+
+                        <p>OKAPI was started in August 2011 at the OCPL code branch,
+                        and it was deployed to the OCDE branch in April 2013.</p>
 
                         <h2 id='comments'>Comments</h2>
 

--- a/okapi/views/changelog.tpl.php
+++ b/okapi/views/changelog.tpl.php
@@ -27,14 +27,14 @@
                     </td>
                     <td class='article'>
 
-                        <h1>Changes of the OKAPI interface or adminstration</h1>
+                        <h1>Changes of the OKAPI interface or administration</h1>
 
                         <?php
                         $br = '';
                         foreach ($vars['changes'] as $type => $changes) {
                             if (count($changes)) {
-                                if ($type == 'uninstalled') {
-                                    echo "<p>The following changes are not availble yet at " . $vars['site_name'] . ":</p>";
+                                if ($type == 'unavailable') {
+                                    echo "<p>The following changes are not available yet at " . $vars['site_name'] . ":</p>";
                                     $br = '<br />';
                                 } else {
                                     echo "<p>".$br."The following changes are available at " . $vars['site_name'] . ":</p>";

--- a/okapi/views/changelog.tpl.php
+++ b/okapi/views/changelog.tpl.php
@@ -29,6 +29,10 @@
 
                         <h1>Changes to the OKAPI interface or administration</h1>
 
+                        <?php if (!$vars['changes']['available']) { ?>
+                        <p><em>The Changelog is currently not available.</em></p>
+                        <?php } else { ?>
+
                         <p>Changes to the interface are always backward compatible.
                         You need not to update your applications after any change.
                         But there may be new <b>recommendations</b> (indicated by
@@ -71,9 +75,11 @@
                         <p>OKAPI was started in August 2011 at the OCPL code branch,
                         and it was deployed to the OCDE branch in April 2013.</p>
 
+                        <?php } ?>
+
                         <h2 id='comments'>Comments</h2>
 
-                        <div class='issue-comments' issue_id='TODO'></div>
+                        <div class='issue-comments' issue_id='407'></div>
 
                     </td>
                 </tr></table>

--- a/okapi/views/changelog.tpl.php
+++ b/okapi/views/changelog.tpl.php
@@ -26,6 +26,9 @@
                         <?= $vars['menu'] ?>
                     </td>
                     <td class='article'>
+                        <div class="floaticonlink">
+                            <a href="changelog_feed"><img src="static/rss-feed.svg" width="32px" /></a>
+                        </div>
 
                         <h1>Changes to the OKAPI interface or administration</h1>
 
@@ -58,7 +61,7 @@
                                 <?php foreach($changes as $change) { ?>
                                     <tr>
                                         <td><a href="https://github.com/opencaching/okapi/tree/<?= $change['commit'] ?>"><?= $change['version'] ?></a></td>
-                                        <td><?= $change['date'] ?></td>
+                                        <td><?= substr($change['date'], 0, 10) ?></td>
                                         <td><?= ($change['type'] == 'bugfix' ? 'Fixed:' : '') . $change['comment'] ?></td>
                                     </tr>
                                 <?php } ?>

--- a/okapi/views/changelog.tpl.php
+++ b/okapi/views/changelog.tpl.php
@@ -59,7 +59,7 @@
                                         <th>Change</th>
                                     </th>
                                 <?php foreach($changes as $change) { ?>
-                                    <tr>
+                                    <tr id="v<?= $change['version'] ?>">
                                         <td><a href="https://github.com/opencaching/okapi/tree/<?= $change['commit'] ?>"><?= $change['version'] ?></a></td>
                                         <td><?= substr($change['time'], 0, 10) ?></td>
                                         <td><?= ($change['type'] == 'bugfix' ? 'Fixed: ' : '') . $change['comment'] ?></td>

--- a/okapi/views/changelog.tpl.php
+++ b/okapi/views/changelog.tpl.php
@@ -1,0 +1,71 @@
+<!doctype html>
+<html lang='en'>
+    <head>
+        <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+        <title>OKAPI Changelog</title>
+        <link rel="stylesheet" href="<?= $vars['okapi_base_url'] ?>static/common.css?<?= $vars['okapi_rev'] ?>">
+        <link rel="icon" type="image/x-icon" href="<?= $vars['okapi_base_url'] ?>static/favicon.ico">
+        <script src='https://ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js'></script>
+        <script>
+            var okapi_base_url = "<?= $vars['okapi_base_url'] ?>";
+            $(function() {
+                $('h2').each(function() {
+                    $('#toc').append($("<div></div>").append($("<a></a>")
+                        .text($(this).text()).attr("href", "#" + $(this).attr('id'))));
+                });
+            });
+        </script>
+        <script src='<?= $vars['okapi_base_url'] ?>static/common.js?<?= $vars['okapi_rev'] ?>'></script>
+    </head>
+    <body class='api'>
+        <div class='okd_mid'>
+            <div class='okd_top'>
+                <?php include 'installations_box.tpl.php'; ?>
+                <table cellspacing='0' cellpadding='0'><tr>
+                    <td class='apimenu'>
+                        <?= $vars['menu'] ?>
+                    </td>
+                    <td class='article'>
+
+                        <h1>Changes of the OKAPI interface or adminstration</h1>
+
+                        <?php
+                        $br = '';
+                        foreach ($vars['changes'] as $type => $changes) {
+                            if (count($changes)) {
+                                if ($type == 'uninstalled') {
+                                    echo "<p>The following changes are not availble yet at " . $vars['site_name'] . ":</p>";
+                                    $br = '<br />';
+                                } else {
+                                    echo "<p>".$br."The following changes are available at " . $vars['site_name'] . ":</p>";
+                                } ?>
+
+                                <table cellspacing='1px' class='changelog'>
+                                    <tr>
+                                        <th>Version</th>
+                                        <th>Date</th>
+                                        <th>Change</th>
+                                    </th>
+                                <?php foreach($changes as $change) { ?>
+                                    <tr>
+                                        <td><a href="https://github.com/opencaching/okapi/tree/<?= $change['commit'] ?>"><?= $change['version'] ?></a></td>
+                                        <td><?= $change['date'] ?></td>
+                                        <td><?= ($change['type'] == 'bugfix' ? 'Fixed:' : '') . (string)$change ?></td>
+                                    </tr>
+                                <?php } ?>
+                                </table>
+                            <?php } ?>
+                        <?php } ?>
+
+                        <h2 id='comments'>Comments</h2>
+
+                        <div class='issue-comments' issue_id='TODO'></div>
+
+                    </td>
+                </tr></table>
+            </div>
+            <div class='okd_bottom'>
+            </div>
+        </div>
+    </body>
+</html>

--- a/okapi/views/changelog.tpl.php
+++ b/okapi/views/changelog.tpl.php
@@ -30,9 +30,9 @@
                         <h1>Changes to the OKAPI interface or administration</h1>
 
                         <p>Changes to the interface are always backward compatible.
-                        You need not to update your applications after any change (but
-                        there may be new <em>recommendations</em> on how to use OKAPI
-                        methods).</p>
+                        You need not to update your applications after any change.
+                        But there may be new <b>recommendations</b> (indicated by
+                        bold text) on how to use OKAPI methods.</p>
 
                         <?php
                         $br = '';

--- a/okapi/views/changelog.tpl.php
+++ b/okapi/views/changelog.tpl.php
@@ -61,8 +61,8 @@
                                 <?php foreach($changes as $change) { ?>
                                     <tr>
                                         <td><a href="https://github.com/opencaching/okapi/tree/<?= $change['commit'] ?>"><?= $change['version'] ?></a></td>
-                                        <td><?= substr($change['date'], 0, 10) ?></td>
-                                        <td><?= ($change['type'] == 'bugfix' ? 'Fixed:' : '') . $change['comment'] ?></td>
+                                        <td><?= substr($change['time'], 0, 10) ?></td>
+                                        <td><?= ($change['type'] == 'bugfix' ? 'Fixed: ' : '') . $change['comment'] ?></td>
                                     </tr>
                                 <?php } ?>
                                 </table>

--- a/okapi/views/changelog_feed.php
+++ b/okapi/views/changelog_feed.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace okapi\views\changelog_feed;
+
+use Exception;
+use okapi\Okapi;
+use okapi\Settings;
+use okapi\OkapiRequest;
+use okapi\OkapiHttpResponse;
+use okapi\views\changelog\Changelog;
+
+
+class View
+{
+    public static function call()
+    {
+        require_once($GLOBALS['rootpath'].'okapi/views/changelog_helper.inc.php');
+
+        $changelog = new Changelog();
+        $changes = array_merge($changelog->unavailable_changes, $changelog->available_changes);
+        $changes = array_slice($changes, 0, 20);
+
+        $vars = array(
+            'changes' => $changes,
+            'site_url' => Settings::get('SITE_URL'),
+        );
+
+        $response = new OkapiHttpResponse();
+        $response->content_type = "application/rss+xml; charset=utf-8";
+        ob_start();
+        include 'changelog_feed.tpl.php';
+        $response->body = ob_get_clean();
+        return $response;
+    }
+}

--- a/okapi/views/changelog_feed.tpl.php
+++ b/okapi/views/changelog_feed.tpl.php
@@ -12,7 +12,7 @@
         <item>
             <title>Version <?= $change['version'] ?></title>
             <link>https://github.com/opencaching/okapi/tree/<?= $change['commit'] ?></link>
-            <pubDate><?= date('r', strtotime($change['date'])) ?></pubDate>
+            <pubDate><?= date('r', strtotime($change['time'])) ?></pubDate>
             <category><?= $change['type'] ?></category>
             <description><![CDATA[<?= $change['comment'] ?>]]></description>
         </item>

--- a/okapi/views/changelog_feed.tpl.php
+++ b/okapi/views/changelog_feed.tpl.php
@@ -1,17 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:sy="http://purl.org/rss/1.0/modules/syndication/">
+<rss version="2.0" xml:lang="en" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:sy="http://purl.org/rss/1.0/modules/syndication/">
     <channel>
-        <title>OKAPI changelog</title>
-        <atom:link href="<?= $vars['site_url'] ?>changelog_feed" rel="self" type="application/rss+xml" />
-        <link><?= $vars['site_url'] ?></link>
+        <title>OKAPI Changelog</title>
+        <link><?= $vars['site_url'] ?>okapi</link>
+        <atom:link href="<?= $vars['site_url'] ?>okapi/changelog_feed" rel="self" type="application/rss+xml" />
         <description>Changes to OKAPI - the publically available API for Opencaching sites</description>
         <language>en-EN</language>
+        <ttl>60</ttl>
         <sy:updatePeriod>hourly</sy:updatePeriod>
         <sy:updateFrequency>1</sy:updateFrequency>
 <?php foreach ($vars['changes'] as $change) { ?>
         <item>
             <title>Version <?= $change['version'] ?></title>
-            <link>https://github.com/opencaching/okapi/tree/<?= $change['commit'] ?></link>
+            <link><?= $vars['site_url'] ?>okapi/changelog.html#v<?= $change['version'] ?></link>
+            <guid><?= $vars['site_url'] ?>okapi/changelog.html#v<?= $change['version'] ?></guid>
             <pubDate><?= date('r', strtotime($change['time'])) ?></pubDate>
             <category><?= $change['type'] ?></category>
             <description><![CDATA[<?= $change['comment'] ?>]]></description>

--- a/okapi/views/changelog_feed.tpl.php
+++ b/okapi/views/changelog_feed.tpl.php
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:sy="http://purl.org/rss/1.0/modules/syndication/">
+    <channel>
+        <title>OKAPI changelog</title>
+        <atom:link href="<?= $vars['site_url'] ?>changelog_feed" rel="self" type="application/rss+xml" />
+        <link><?= $vars['site_url'] ?></link>
+        <description>Changes to OKAPI - the publically available API for Opencaching sites</description>
+        <language>en-EN</language>
+        <sy:updatePeriod>hourly</sy:updatePeriod>
+        <sy:updateFrequency>1</sy:updateFrequency>
+<?php foreach ($vars['changes'] as $change) { ?>
+        <item>
+            <title>Version <?= $change['version'] ?></title>
+            <link>https://github.com/opencaching/okapi/tree/<?= $change['commit'] ?></link>
+            <pubDate><?= date('r', strtotime($change['date'])) ?></pubDate>
+            <category><?= $change['type'] ?></category>
+            <description><![CDATA[<?= $change['comment'] ?>]]></description>
+        </item>
+<?php } ?>
+    </channel>
+</rss>

--- a/okapi/views/changelog_helper.inc.php
+++ b/okapi/views/changelog_helper.inc.php
@@ -73,26 +73,36 @@ class Changelog
         else
         {
             $commits = array();
+            $versions = array();
 
             foreach ($changelog->changes->change as $change) {
-                if ($change['version'] == '' || $change['time'] == '') {
-                    throw new Exception("Someone forgot to run update_changes.php.");
-                } elseif (isset($commits[(string)$change['commit']])) {
-                    throw new Exception("Duplicate commit " . $change['commit'] . " in changelog.");
-                } else {
-                    $change = array(
-                        'commit' => (string)$change['commit'],
-                        'version' => (string)$change['version'],
-                        'time' => (string)$change['time'],
-                        'type' => (string)$change['type'],
-                        'comment' => trim(self::get_inner_xml($change)),
+                $change = array(
+                    'commit' => (string)$change['commit'],
+                    'version' => (string)$change['version'],
+                    'time' => (string)$change['time'],
+                    'type' => (string)$change['type'],
+                    'comment' => trim(self::get_inner_xml($change)),
+                );
+                if (strlen($change['commit']) != 8
+                    || $change['version'] == 0
+                    || $change['time'] == ''
+                    || isset($commits[$change['commit']])
+                    || isset($versions[$change['version']])
+                ) {
+                    # All of these problems would have been detected or prevented
+                    # by update_changes.
+
+                    throw new Exception(
+                        "Someone forgot to run update_changes.php (or ignored error messages)."
                     );
+                } else {
                     if ($change['version'] > Okapi::$version_number) {
                         $this->unavailable_changes[] = $change;
                     } else {
                         $this->available_changes[] = $change;
                     }
                     $commits[$change['commit']] = true;
+                    $versions[$change['version']] = true;
                 }
             }
         }

--- a/okapi/views/changelog_helper.inc.php
+++ b/okapi/views/changelog_helper.inc.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace okapi\views\changelog;
+
+use Exception;
+use okapi\Okapi;
+use okapi\Cache;
+
+
+class Changelog
+{
+    public $unavailable_changes = array();
+    public $available_changes = array();
+
+    public function __construct()
+    {
+        $cache_key = 'changelog';
+        $cache_backup_key = 'changelog-backup';
+
+        $changes_xml = Cache::get($cache_key);
+        $changelog = null;
+
+        if (!$changes_xml)
+        {
+            # Download the current changelog.
+
+            try
+            {
+                $opts = array(
+                    'http' => array(
+                        'method' => "GET",
+                        'timeout' => 5.0
+                    )
+                );
+                $context = stream_context_create($opts);
+                $changes_xml = file_get_contents(
+                     # TODO: load from OKAPI repo
+                    'https://raw.githubusercontent.com/following5/okapi/feature/changelog/etc/changes.xml',
+                    false, $context
+                );
+                $changelog = simplexml_load_string($changes_xml);
+                if (!$changelog) {
+                    throw new ErrorException();
+                }
+                Cache::set($cache_key, $changes_xml, 3600);
+                Cache::set($cache_backup_key, $changes_xml, 3600*24*30);
+            }
+            catch (Exception $e)
+            {
+                # GitHub failed on us. User backup list, if available.
+
+                $changes_xml = Cache::get($cache_backup_key);
+                if ($changes_xml) {
+                    Cache::set($cache_key, $changes_xml, 3600*12);
+                }
+            }
+        }
+
+        if (!$changelog && $changes_xml) {
+            $changelog = simplexml_load_string($changes_xml);
+        }
+        # TODO: verify XML scheme
+
+        $this->unavailable_changes = array();
+        $this->available_changes = array();
+
+        if (!$changelog)
+        {
+            # We could not retreive the changelog from Github, and there was
+            # no backup key or it expired. Probably we are on a developer
+            # machine. The template will output some error message.
+        }
+        else
+        {
+            $commits = array();
+
+            foreach ($changelog->changes->change as $change) {
+                if ($change['version'] == '' || $change['date'] == '') {
+                    throw new Exception("Someone forgot to run update_changes.php.");
+                } elseif (isset($commits[(string)$change['commit']])) {
+                    throw new Exception("Duplicate commit " . $change['commit'] . " in changelog.");
+                } else {
+                    $change = array(
+                        'commit' => (string)$change['commit'],
+                        'version' => (string)$change['version'],
+                        'date' => (string)$change['date'],
+                        'type' => (string)$change['type'],
+                        'comment' => trim(self::get_inner_xml($change)),
+                    );
+                    if ($change['version'] > Okapi::$version_number) {
+                        $this->unavailable_changes[] = $change;
+                    } else {
+                        $this->available_changes[] = $change;
+                    }
+                    $commits[$change['commit']] = true;
+                }
+            }
+        }
+    }
+
+    private static function get_inner_xml($node)
+    {
+        /* Fetch as <some-node>content</some-node>, extract content. */
+
+        $s = $node->asXML();
+        $start = strpos($s, ">") + 1;
+        $length = strlen($s) - $start - (3 + strlen($node->getName()));
+        $s = substr($s, $start, $length);
+
+        return $s;
+    }
+}

--- a/okapi/views/changelog_helper.inc.php
+++ b/okapi/views/changelog_helper.inc.php
@@ -75,7 +75,7 @@ class Changelog
             $commits = array();
 
             foreach ($changelog->changes->change as $change) {
-                if ($change['version'] == '' || $change['date'] == '') {
+                if ($change['version'] == '' || $change['time'] == '') {
                     throw new Exception("Someone forgot to run update_changes.php.");
                 } elseif (isset($commits[(string)$change['commit']])) {
                     throw new Exception("Duplicate commit " . $change['commit'] . " in changelog.");
@@ -83,7 +83,7 @@ class Changelog
                     $change = array(
                         'commit' => (string)$change['commit'],
                         'version' => (string)$change['version'],
-                        'date' => (string)$change['date'],
+                        'time' => (string)$change['time'],
                         'type' => (string)$change['type'],
                         'comment' => trim(self::get_inner_xml($change)),
                     );

--- a/okapi/views/menu.inc.php
+++ b/okapi/views/menu.inc.php
@@ -30,6 +30,7 @@ class OkapiMenu
         $chunks[] = self::link($current_path, "introduction.html", "Introduction");
         $chunks[] = self::link($current_path, "signup.html", "Sign up");
         $chunks[] = self::link($current_path, "examples.html", "Examples");
+        $chunks[] = self::link($current_path, "changelog.html", "Changelog");
         $chunks[] = "</div>";
 
         # We need a list of all methods. We do not need their descriptions, so


### PR DESCRIPTION
This is a sample implementation for the new OKAPI changelog.

If you decrease the version number in core.php, the changelog will split up in a section with unavailable changes and a section with available changes on the site.