### PR TITLE
Feature/remove php4 based constructor

### DIFF
--- a/okapi/views/devel/comparator.inc.php
+++ b/okapi/views/devel/comparator.inc.php
@@ -60,7 +60,7 @@ class dbStructUpdater
     * Constructor
     * @access public
     */
-    function dbStructUpdater()
+    function __construct()
     {
         $this->init();
     }


### PR DESCRIPTION
Relaying on issue #426 i removed old php4 constructor for php7 compatibility 