### PR TITLE
Update installations site_urls to use HTTPS

### DIFF
--- a/etc/installations.xml
+++ b/etc/installations.xml
@@ -4,10 +4,10 @@
     read by every OKAPI installation, *directly from repository*. See the code for
     services/apisrv/installations method for explanation.
     -->
-    <installation site_url="http://opencaching.pl/"/>
-    <installation site_url="http://www.opencaching.de/"/>
-    <installation site_url="http://www.opencaching.us/"/>
+    <installation site_url="https://opencaching.pl/"/>
+    <installation site_url="https://www.opencaching.de/"/>
+    <installation site_url="https://www.opencaching.us/"/>
     <installation site_url="http://www.opencaching.nl/"/>
     <installation site_url="http://www.opencaching.ro/"/>
-    <installation site_url="http://opencache.uk/"/>
+    <installation site_url="https://opencache.uk/"/>
 </installations>


### PR DESCRIPTION
HTTPS should be used whenever possible through the API.
API endpoint `okapi/services/apisrv/installation` is already
returning `site_url` with HTTPS.