### PR TITLE
Show error message in JS API example

### DIFF
--- a/okapi/static/examples/javascript_nearest.html
+++ b/okapi/static/examples/javascript_nearest.html
@@ -61,7 +61,7 @@
                                 });
                             },
                             function (error) {
-                                $('#results').text("Your browser refused to give me your location.");
+                                $('#results').text("Error :( Message: " + error.message);
                             }
                         );
                     } else {


### PR DESCRIPTION
Since there might be a bunch of reasons to fail
asking for geolocation, JS example should display
more information on fail.