### PR TITLE
implemented attrs=gc_ocde:attrs for OCPL; updates #346

### DIFF
--- a/okapi/services/attrs/AttrHelper.php
+++ b/okapi/services/attrs/AttrHelper.php
@@ -95,6 +95,7 @@ class AttrHelper
             $attr = array(
                 'acode' => (string)$attrnode['acode'],
                 'gc_equivs' => array(),
+                'gc_ocde_equiv' => null,
                 'internal_id' => null,
                 'names' => array(),
                 'descriptions' => array(),
@@ -145,6 +146,18 @@ class AttrHelper
                     $innerxml = preg_replace("/(^[^>]+>)|(<[^<]+$)/us", "", $xml);
                     $attr['descriptions'][$lang] = self::cleanup_string($innerxml);
                 }
+            }
+            foreach ($attrnode->ocgs as $ocgsnode)
+            {
+                if (isset($attr['gc_ocde_equiv']))
+                    throw new Exception("Duplicate ocgs entries for ".$attr['acode']);
+                if (!isset($attr['names']['en']))
+                    throw new Exception("(English) name is missing for ".$attr['acode']." ocgs entry.");
+                $attr['gc_ocde_equiv'] = array(
+                    'id' => (int)$ocgsnode['id'],
+                    'inc' => in_array((string)$ocgsnode['inc'], array("true", "1")) ? 1 : 0,
+                    'name' => $attr['names']['en']
+                );
             }
             $cachedvalue['attr_dict'][$attr['acode']] = $attr;
         }

--- a/okapi/services/attrs/attribute-definitions.xml
+++ b/okapi/services/attrs/attribute-definitions.xml
@@ -132,6 +132,12 @@ https://gist.github.com/DieBatzen/5814dc7368c1034470c8/
 
 *** These are special attributes, not available to the regular user.
 
+For Opencaching attributes which have no Groundspeak equivalents, additional
+Pseudo-Groundspeak IDs ("ocgs" IDs) have been defined, which are used to
+store these attributes in GPX <groundspeak:attribute> elements.
+See OCDE htdocs/lib2/search/search.gpx.inc.php and OCPL lib/format.gpx.inc.php
+for the original implementations.
+
 -->
 
 <xml>
@@ -141,6 +147,7 @@ https://gist.github.com/DieBatzen/5814dc7368c1034470c8/
     -->
 
     <attr acode="A1" categories="de-listing">
+        <ocgs id="106" inc="true" />
         <opencaching schema="OCDE" id="6" />
         <opencaching schema="OCNL" id="6" />
         <opencaching schema="OCRO" id="6" />
@@ -199,6 +206,7 @@ https://gist.github.com/DieBatzen/5814dc7368c1034470c8/
     </attr>
 
     <attr acode="A2" categories="de-cache-types">
+        <ocgs id="117" inc="true" />
         <opencaching schema="OCPL" id="54" />
         <opencaching schema="OCNL" id="54" />
         <opencaching schema="OCRO" id="54" />
@@ -237,6 +245,7 @@ https://gist.github.com/DieBatzen/5814dc7368c1034470c8/
     </attr>
 
     <attr acode="A3" categories="de-cache-types">
+        <ocgs id="118" inc="true" />
         <opencaching schema="OCPL" id="55" />
         <opencaching schema="OCRO" id="55" />
         <lang id="en">
@@ -275,6 +284,7 @@ https://gist.github.com/DieBatzen/5814dc7368c1034470c8/
     </attr>
 
     <attr acode="A4" categories="de-cache-types">
+        <ocgs id="108" inc="true" />
         <opencaching schema="OCDE" id="8" />
         <opencaching schema="OCPL" id="56" />
         <opencaching schema="OCNL" id="56" />
@@ -344,6 +354,7 @@ https://gist.github.com/DieBatzen/5814dc7368c1034470c8/
     </attr>
 
     <attr acode="A5" categories="de-cache-types">
+        <ocgs id="112" inc="true" />
         <opencaching schema="OCPL" id="43" />
         <opencaching schema="OCRO" id="43" />
         <opencaching schema="OCNL" id="43" />
@@ -386,6 +397,7 @@ https://gist.github.com/DieBatzen/5814dc7368c1034470c8/
     </attr>
 
     <attr acode="A6" categories="de-cache-types">
+        <ocgs id="149" inc="true" />
         <opencaching schema="OCPL" id="49" />
         <opencaching schema="OCRO" id="49" />
         <opencaching schema="OCNL" id="49" />
@@ -422,6 +434,7 @@ https://gist.github.com/DieBatzen/5814dc7368c1034470c8/
     </attr>
 
     <attr acode="A7" categories="de-cache-types">
+        <ocgs id="114" inc="true" />
         <opencaching schema="OCPL" id="50" />
         <opencaching schema="OCRO" id="50" />
         <opencaching schema="OCNL" id="50" />
@@ -464,6 +477,7 @@ https://gist.github.com/DieBatzen/5814dc7368c1034470c8/
     </attr>
 
     <attr acode="A8" categories="de-cache-types">
+        <ocgs id="115" inc="true" />
         <opencaching schema="OCPL" id="51" />
         <opencaching schema="OCRO" id="51" />
         <lang id="en">
@@ -541,6 +555,7 @@ https://gist.github.com/DieBatzen/5814dc7368c1034470c8/
     </attr>
 
     <attr acode="A10" categories="de-cache-types">
+        <ocgs id="116" inc="true" />
         <opencaching schema="OCPL" id="53" />
         <opencaching schema="OCRO" id="53" />
         <opencaching schema="OCNL" id="53" />
@@ -590,6 +605,7 @@ https://gist.github.com/DieBatzen/5814dc7368c1034470c8/
     </attr>
 
     <attr acode="A11" categories="de-cache-types">
+        <ocgs id="131" inc="true" />
         <opencaching schema="OCDE" id="31" />
         <opencaching schema="OCUK" id="31" />
         <lang id="en">
@@ -634,6 +650,7 @@ https://gist.github.com/DieBatzen/5814dc7368c1034470c8/
     </attr>
 
     <attr acode="A12" categories="de-cache-types">
+        <ocgs id="132" inc="true" />
         <opencaching schema="OCDE" id="32" />
         <opencaching schema="OCUK" id="32" />
         <lang id="en">
@@ -677,6 +694,7 @@ https://gist.github.com/DieBatzen/5814dc7368c1034470c8/
     </attr>
 
     <attr acode="A13" categories="de-cache-types">
+        <ocgs id="157" inc="true" />
         <opencaching schema="OCDE" id="57" />
         <opencaching schema="OCUK" id="57" />
         <lang id="en">
@@ -709,6 +727,7 @@ https://gist.github.com/DieBatzen/5814dc7368c1034470c8/
     </attr>
 
     <attr acode="A14" categories="de-preconditions">
+        <ocgs id="154" inc="true" />
         <opencaching schema="OCDE" id="54" />
         <opencaching schema="OCUK" id="54" />
         <lang id="en">
@@ -778,6 +797,7 @@ https://gist.github.com/DieBatzen/5814dc7368c1034470c8/
     </attr>
 
     <attr acode="A16" categories="de-preconditions">
+        <ocgs id="156" inc="true" />
         <opencaching schema="OCDE" id="56" />
         <opencaching schema="OCUK" id="56" />
         <lang id="en">
@@ -812,6 +832,7 @@ https://gist.github.com/DieBatzen/5814dc7368c1034470c8/
     </attr>
 
     <attr acode="A17" categories="de-preconditions">
+        <ocgs id="158" inc="true" />
         <opencaching schema="OCDE" id="58" />
         <opencaching schema="OCUK" id="58" />
         <lang id="en">
@@ -914,6 +935,7 @@ https://gist.github.com/DieBatzen/5814dc7368c1034470c8/
     </attr>
 
     <attr acode="A20" categories="de-accessibility">
+        <ocgs id="122" inc="true" />
         <opencaching schema="OCPL" id="84" />
         <opencaching schema="OCRO" id="84" />
         <opencaching schema="OCNL" id="84" />
@@ -1037,6 +1059,7 @@ https://gist.github.com/DieBatzen/5814dc7368c1034470c8/
     </attr>
 
     <attr acode="A23" categories="de-accessibility">
+        <ocgs id="127" inc="true" />
         <opencaching schema="OCDE" id="27" />
         <opencaching schema="OCUK" id="27" />
         <lang id="en">
@@ -1215,6 +1238,7 @@ https://gist.github.com/DieBatzen/5814dc7368c1034470c8/
     </attr>
 
     <attr acode="A28" categories="de-location">
+        <ocgs id="119" inc="true" />
         <opencaching schema="OCPL" id="60" />
         <opencaching schema="OCNL" id="60" />
         <opencaching schema="OCRO" id="60" />
@@ -1254,6 +1278,7 @@ https://gist.github.com/DieBatzen/5814dc7368c1034470c8/
     </attr>
 
     <attr acode="A29" categories="de-location">
+        <ocgs id="120" inc="true" />
         <opencaching schema="OCPL" id="61" />
         <opencaching schema="OCNL" id="61" />
         <opencaching schema="OCRO" id="61" />
@@ -1295,6 +1320,7 @@ https://gist.github.com/DieBatzen/5814dc7368c1034470c8/
     </attr>
 
     <attr acode="A30" categories="de-location">
+        <ocgs id="130" inc="true" />
         <opencaching schema="OCDE" id="30" />
         <opencaching schema="OCUK" id="30" />
         <lang id="en">
@@ -1348,6 +1374,7 @@ https://gist.github.com/DieBatzen/5814dc7368c1034470c8/
     </attr>
 
     <attr acode="A31" categories="de-location">
+        <ocgs id="133" inc="true" />
         <opencaching schema="OCDE" id="33" />
         <opencaching schema="OCUK" id="33" />
         <lang id="en">
@@ -1381,6 +1408,7 @@ https://gist.github.com/DieBatzen/5814dc7368c1034470c8/
     </attr>
 
     <attr acode="A32" categories="de-location">
+        <ocgs id="134" inc="true" />
         <opencaching schema="OCDE" id="34" />
         <opencaching schema="OCUK" id="34" />
         <lang id="en">
@@ -1606,6 +1634,7 @@ https://gist.github.com/DieBatzen/5814dc7368c1034470c8/
     </attr>
 
     <attr acode="A38" categories="de-facilities">
+        <ocgs id="123" inc="true" />
         <opencaching schema="OCDE" id="23" />
         <opencaching schema="OCUK" id="23" />
         <lang id="en">
@@ -1920,6 +1949,7 @@ https://gist.github.com/DieBatzen/5814dc7368c1034470c8/
     </attr>
 
     <attr acode="A46" categories="de-time-and-seasons">
+        <ocgs id="143" inc="true" />
         <opencaching schema="OCDE" id="43" />
         <opencaching schema="OCUK" id="43" />
         <lang id="en">
@@ -1999,6 +2029,7 @@ https://gist.github.com/DieBatzen/5814dc7368c1034470c8/
     </attr>
 
     <attr acode="A48" categories="de-time-and-seasons">
+        <ocgs id="142" inc="true" /><!-- Yes! Not 141. -->
         <opencaching schema="OCDE" id="41" />
         <opencaching schema="OCUK" id="41" />
         <lang id="en">
@@ -2019,6 +2050,7 @@ https://gist.github.com/DieBatzen/5814dc7368c1034470c8/
     </attr>
 
     <attr acode="A49" categories="de-tools">
+        <ocgs id="147" inc="true" />
         <opencaching schema="OCPL" id="47" />
         <opencaching schema="OCDE" id="47" />
         <opencaching schema="OCNL" id="47" />
@@ -2068,6 +2100,7 @@ https://gist.github.com/DieBatzen/5814dc7368c1034470c8/
     </attr>
 
     <attr acode="A50" categories="de-tools">
+        <ocgs id="113" inc="true" />
         <opencaching schema="OCPL" id="48" />
         <opencaching schema="OCNL" id="48" />
         <opencaching schema="OCRO" id="48" />
@@ -2102,6 +2135,7 @@ https://gist.github.com/DieBatzen/5814dc7368c1034470c8/
     </attr>
 
     <attr acode="A51" categories="de-tools">
+        <ocgs id="121" inc="true" />
         <opencaching schema="OCPL" id="81" />
         <opencaching schema="OCRO" id="81" />
         <opencaching schema="OCNL" id="81" />
@@ -2220,6 +2254,7 @@ https://gist.github.com/DieBatzen/5814dc7368c1034470c8/
     </attr>
 
     <attr acode="A54" categories="de-tools">
+        <ocgs id="150" inc="true" />
         <opencaching schema="OCDE" id="50" />
         <opencaching schema="OCUK" id="50" />
         <lang id="en">
@@ -2424,6 +2459,7 @@ https://gist.github.com/DieBatzen/5814dc7368c1034470c8/
     </attr>
 
     <attr acode="A58" categories="de-tools">
+        <ocgs id="135" inc="true" />
         <opencaching schema="OCDE" id="35" />
         <opencaching schema="OCUK" id="35" />
         <lang id="en">
@@ -2521,6 +2557,7 @@ https://gist.github.com/DieBatzen/5814dc7368c1034470c8/
     </attr>
 
     <attr acode="A60" categories="de-dangers">
+        <ocgs id="110" inc="true" />
         <opencaching schema="OCDE" id="10" />
         <opencaching schema="OCUK" id="10" />
         <lang id="en">
@@ -2873,6 +2910,7 @@ https://gist.github.com/DieBatzen/5814dc7368c1034470c8/
     </attr>
 
     <attr acode="A68" categories="de-rating">
+        <ocgs id="111" inc="true" />
         <opencaching schema="OCPL" id="40" />
         <opencaching schema="OCRO" id="40" />
         <opencaching schema="OCNL" id="40" />
@@ -2909,6 +2947,7 @@ https://gist.github.com/DieBatzen/5814dc7368c1034470c8/
     </attr>
 
     <attr acode="A69" categories="de-rating">
+        <ocgs id="137" inc="true" />
         <opencaching schema="OCDE" id="37" />
         <opencaching schema="OCUK" id="37" />
         <lang id="en">
@@ -3035,6 +3074,7 @@ https://gist.github.com/DieBatzen/5814dc7368c1034470c8/
     </attr>
 
     <attr acode="A72" categories="de-cache-types">
+        <ocgs id="161" inc="true" />
         <opencaching schema="OCDE" id="61" />
         <lang id="en">
             <name>Reverse Cache</name>
@@ -3124,6 +3164,7 @@ https://gist.github.com/DieBatzen/5814dc7368c1034470c8/
     </attr>
 
     <attr acode="A75" categories="de-tools">
+        <ocgs id="153" inc="true" />
         <opencaching schema="OCDE" id="53" /><!-- deprecated -->
         <opencaching schema="OCUK" id="156" />
         <lang id="en">
@@ -3166,6 +3207,7 @@ https://gist.github.com/DieBatzen/5814dc7368c1034470c8/
     </attr>
 
     <attr acode="A76" categories="de-accessibility">
+        <ocgs id="125" inc="true" />
         <opencaching schema="OCUK" id="157" />
         <lang id="en">
             <name>Rated on Handicaching.com</name>
@@ -3205,6 +3247,7 @@ https://gist.github.com/DieBatzen/5814dc7368c1034470c8/
     </attr>
 
     <attr acode="A77" categories="de-cache-types">
+        <ocgs id="126" inc="true" />
         <opencaching schema="OCUK" id="158" />
         <lang id="en">
             <name>Contains a Munzee</name>

--- a/okapi/services/attrs/attribute/docs.xml
+++ b/okapi/services/attrs/attribute/docs.xml
@@ -96,6 +96,29 @@
                 that one Geocaching.com ID may be present in many gc_equivs.</p>
             </li>
             <li>
+                <p><b>gc_ocde_equiv</b> - a Groundspeak-like attribute with ID &gt;
+                100, which may be included in GPX files if there is no <em>gc_equiv</em>
+                for the OC attribute; a dictionary of the following structure:</p>
+
+                <ul>
+                    <li><b>id</b> - Groundspeak-like ID of the attribute,</li>
+                    <li>
+                        <b>inc</b> - integer, either 1 or 0, to be included in GPX
+                        files,
+                    </li>
+                    <li>
+                        <b>name</b> - the name of the attribute, to be included in
+                        GPX files
+                    </li>
+                </ul>
+
+                <p>Note: We cannot guarantee that the ID of these Groundspeak-like
+                attributes will forever stay the same. If you need a unique attribute
+                ID, use the <b>acode</b> instead.</p>
+                <p>See <a href='%OKAPI:methodargref:services/caches/formatters/gpx%'>caches/formatters/gpx</a>
+                <em>attrs=gc_ocde:attrs</em> option for more explanation.</p>
+            </li>
+            <li>
                 <p><b>is_locally_used</b> - boolean, indicates if the attribute is <i>currently</i>
                 used by <i>this</i> Opencaching server. Or, to be more specific, <b>true</b>
                 means that the attribute can currently be included in the <b>attr_acodes</b> field

--- a/okapi/services/attrs/attribute/docs.xml
+++ b/okapi/services/attrs/attribute/docs.xml
@@ -98,7 +98,8 @@
             <li>
                 <p><b>gc_ocde_equiv</b> - a Groundspeak-like attribute with ID &gt;
                 100, which may be included in GPX files if there is no <em>gc_equiv</em>
-                for the OC attribute; a dictionary of the following structure:</p>
+                for the OC attribute; either <b>null</b> or a dictionary of the
+                following structure:</p>
 
                 <ul>
                     <li><b>id</b> - Groundspeak-like ID of the attribute,</li>
@@ -107,15 +108,18 @@
                         files,
                     </li>
                     <li>
-                        <b>name</b> - the name of the attribute, to be included in
-                        GPX files
+                        <b>name</b> - the name of the attribute to be included in
+                        GPX files.
                     </li>
                 </ul>
 
                 <p>Note: We cannot guarantee that the ID of these Groundspeak-like
                 attributes will forever stay the same. If you need a unique attribute
                 ID, use the <b>acode</b> instead.</p>
-                <p>See <a href='%OKAPI:methodargref:services/caches/formatters/gpx%'>caches/formatters/gpx</a>
+                <p>The naming "ocde_" is for historical reasons. This field is
+                available on all up-to-date OKAPI installations and covers all OC
+                attributes without native GC equivalents. See the
+                <a href='%OKAPI:methodargref:services/caches/formatters/gpx%'>caches/formatters/gpx</a>
                 <em>attrs=gc_ocde:attrs</em> option for more explanation.</p>
             </li>
             <li>

--- a/okapi/services/attrs/attributes/WebService.php
+++ b/okapi/services/attrs/attributes/WebService.php
@@ -20,7 +20,7 @@ class WebService
     }
 
     private static $valid_field_names = array(
-        'acode', 'name', 'names', 'description', 'descriptions', 'gc_equivs',
+        'acode', 'name', 'names', 'description', 'descriptions', 'gc_equivs', 'gc_ocde_equiv',
         'is_locally_used', 'is_deprecated', 'local_icon_url', 'is_discontinued'
     );
 

--- a/okapi/services/caches/edit/WebService.php
+++ b/okapi/services/caches/edit/WebService.php
@@ -52,6 +52,23 @@ class WebService
         Okapi::gettext_domain_init($langprefs);
         try
         {
+            /**
+             * Note on attributes:
+             *
+             * At OCDE there is the feature to deprecate attributes. This means
+             * that they are still displayed in geocaches and are retained when
+             * editing, but can no longer be added to geocaches (and no longer
+             * be searched for).
+             *
+             * Currently there are two deprecated OCDE attribs: Aircraft required
+             * (A75) and External listing (no A-code yet). When editing attributes
+             * is implemented in Okapi, developers will need to know which
+             * attribs are deprecated; so this may need some "deprecated" flag
+             * in attribute-definitions.xml and services/attrs/attributes.
+             * Depending on the implementation, an A-code for "External listing"
+             * may be needed.
+             */
+
             # passwd
             $newpw = $request->get_parameter('passwd');
             if ($newpw !== null)

--- a/okapi/services/caches/formatters/gpx/WebService.php
+++ b/okapi/services/caches/formatters/gpx/WebService.php
@@ -146,10 +146,7 @@ class WebService
             if ($elem == 'none') {
                 /* pass */
             } elseif (in_array($elem, array('desc:text', 'ox:tags', 'gc:attrs', 'gc_ocde:attrs'))) {
-                if ($elem == 'gc_ocde:attrs' && Settings::get('OC_BRANCH') != 'oc.de')
-                    $vars['attrs'][] = 'gc:attrs';
-                else
-                    $vars['attrs'][] = $elem;
+                $vars['attrs'][] = $elem;
             } else {
                 throw new InvalidParam('attrs', "Invalid list entry: '$elem'");
             }
@@ -270,7 +267,7 @@ class WebService
                     $request->consumer, $request->token, array(
                         'only_locally_used' => 'true',
                         'langpref' => $langpref,
-                        'fields' => 'name|gc_equivs'
+                        'fields' => 'name|gc_equivs|gc_ocde_equiv'
                     )
                 )
             );
@@ -281,20 +278,6 @@ class WebService
             $vars['gc_ocde_attrs'] = in_array('gc_ocde:attrs', $vars['attrs']);
             if ($vars['gc_attrs'] || $vars['gc_ocde_attrs'])
             {
-                if ($vars['gc_ocde_attrs'])
-                {
-                    # As this is an OCDE compatibility feature, we use the same Pseudo-GS
-                    # attribute names here as OCDE. Note that this code is specific to OCDE
-                    # database; OCPL stores attribute names in a different way and may use
-                    # different names for equivalent attributes.
-
-                    $ocde_attrnames = Db::select_group_by('id',"
-                        select id, name
-                        from cache_attrib
-                    ");
-                    $attr_dict = AttrHelper::get_attrdict();
-                }
-
                 foreach ($vars['caches'] as &$cache_ref)
                 {
                     $cache_ref['gc_attrs'] = array();
@@ -311,22 +294,16 @@ class WebService
                             $cache_ref['gc_attrs'][$gc['id']] = $gc;
                             $has_gc_equivs = true;
                         }
-                        if (!$has_gc_equivs && $vars['gc_ocde_attrs'])
+                        if (!$has_gc_equivs && $vars['gc_ocde_attrs']
+                            && $vars['attr_index'][$acode]['gc_ocde_equiv'] !== null)
                         {
-                            # Generate an OCDE pseudo-GS attribute;
-                            # see https://github.com/opencaching/okapi/issues/190 and
-                            # https://github.com/opencaching/okapi/issues/271.
-                            #
-                            # Groundspeak uses ID 1..65 (as of June, 2013), and OCDE makeshift
-                            # IDs start at 106, so there is space for 40 new GS attributes.
-                            # OCDE 41 maps to GS 142 due to a typo in OCDE code.
+                            # Generate an OC pseudo-GS attribute;
+                            # see https://github.com/opencaching/okapi/issues/190,
+                            # https://github.com/opencaching/okapi/issues/271 and
+                            # https://github.com/opencaching/okapi/issues/346.
 
-                            $internal_id = $attr_dict[$acode]['internal_id'];
-                            $gc_id = ($internal_id == 41 ? 142 : 100 + $internal_id);
-                            $cache_ref['gc_attrs'][$gc_id] = array(
-                                'inc' => 1,
-                                'name' => $ocde_attrnames[$internal_id][0]['name'],
-                            );
+                            $ocgs = $vars['attr_index'][$acode]['gc_ocde_equiv'];
+                            $cache_ref['gc_attrs'][$ocgs['id']] = $ocgs;
                         }
                     }
                     if ($cache_ref['needs_maintenance'])

--- a/okapi/services/caches/formatters/gpx/docs.xml
+++ b/okapi/services/caches/formatters/gpx/docs.xml
@@ -107,15 +107,12 @@
                 Such attributes cannot be included as gc:attrs and will be ignored.</p>
             </li>
             <li>
-                <p>%OKAPI:infotag:ocde-specific% <b>gc_ocde:attrs</b> - attributes will be
+                <p><b>gc_ocde:attrs</b> - attributes will be
                 listed as Groundspeak's <i>groundspeak:attribute</i> elements (<b>ns_ground</b>
                 has to be <b>true</b>). Opencaching attributes which have no Geocaching.com
-                counterparts will be included according to an Opencaching.DE convention, using
-                "makeshift IDs" which may change in the future.</p>
-
-                <p>This alternative is supported only by some OC sites (the ones originating
-                from the OCDE branch). Other sites will handle <b>gc_ocde:attrs</b> in the same
-                way as <b>gc:attrs</b>.</p>
+                counterparts will be included according to an Opencaching.DE convention,
+                which now is implemented at all up-to-date OC sites: They will have IDs
+                &gt; 100.</p>
             </li>
         </ul>
 


### PR DESCRIPTION
This is a major extension to the attribute system, so I think it needs a review.

This change updates the Okapi GPX method so that it (optionally) does the same as OCPL code. The OCPL implementation is out there for half a year now. There were ~ 10 conflicting attribute IDs with the (much older) OCDE implementation, which I have recently resolved in OCPL code. So we now have a clean mapping of all existing OC attribs to `<groundspeak:attribute>', including [prepared](https://github.com/opencaching/opencaching-pl/blob/c8348b3ac70795d789e4f963c9ab0210cb108a51/lib/format.gpx.inc.php#L342) mappings for OC.US.

There is one more issue: If Groundspeak adds more than 39 new attributes and overrides the "OC-GS" attrib ID space (currently 106-161), these OC-GS IDs will get useless. However, GS attributes added rarely these days, and the more the OC-GS ID-space is in use, the more likely GS should respect it.

