### PR TITLE
Update Okapi.php

### DIFF
--- a/okapi/core/Okapi.php
+++ b/okapi/core/Okapi.php
@@ -1162,7 +1162,7 @@ class Okapi
     public static function require_developer_cookie() {
         if (
             (!isset($_COOKIE['okapi_devel_key']))
-            || (md5($_COOKIE['okapi_devel_key']) != '5753f318c1495c01637f7f6b7fc9c5db')
+            || (md5($_COOKIE['okapi_devel_key']) !== '5753f318c1495c01637f7f6b7fc9c5db')
         ) {
             header("Content-Type: text/plain; charset=utf-8");
             print "I need a cookie!";


### PR DESCRIPTION
changed to strict compare to avoid misbehavior, if hash may changed in future

Example:
```php
var_dump(md5('240610708')=='0e46');
bool(true)