### PR TITLE
Proposal for including OCPL "COG comments" (OC team annotations)

### DIFF
--- a/okapi/services/caches/geocache/WebService.php
+++ b/okapi/services/caches/geocache/WebService.php
@@ -36,11 +36,14 @@ class WebService
         if ($user_logs_only === null) $user_logs_only = 'false';
         $attribution_append = $request->get_parameter('attribution_append');
         if (!$attribution_append) $attribution_append = 'full';
+        $oc_team_annotation = $request->get_parameter('oc_team_annotation');
+        if (!$oc_team_annotation) $oc_team_annotation = 'description';
         $params = array(
             'cache_codes' => $cache_code,
             'langpref' => $langpref,
             'fields' => $fields,
             'attribution_append' => $attribution_append,
+            'oc_team_annotation' => $oc_team_annotation,
             'lpc' => $lpc,
             'log_fields' => $log_fields,
             'user_logs_only' => $user_logs_only,

--- a/okapi/services/caches/geocache/docs.xml
+++ b/okapi/services/caches/geocache/docs.xml
@@ -51,6 +51,23 @@
             </li>
         </ul>
     </opt>
+    <opt name='oc_team_annotation' default='description' infotags='ocpl-specific'>
+        <p>Opencaching team members may directly annotate geocache listings.
+        This parameter controls how to retrieve those annotations:</p>
+        <ul>
+            <li><b>description</b> - inserts the OC team annotations into the
+            description texts,</li>
+            <li><b>separate</b> (recommended) - includes the <b>oc_team_annotation</b> field
+            instead.</li>
+        </ul>
+        <p>Please note that you are REQUIRED to display OC team annotations
+        alongside with the owner's cache listing. In this they differ from
+        <i>OC team
+        <a href="%OKAPI:methodargref:services/logs/entry%">log entries</a></i>,
+        which will only be visible when logs are displayed.</p>
+        <p>OC team annotations so far are only in use at OCPL-based sites.
+        OCDE installations will ignore this parameter.</p>
+    </opt>
     <opt name='lpc' default='10'>
         Log-entries per cache - the number of logs returned in the <b>latest_logs</b> field.
         This should be an integer or a special "all" value. Please note, that you must include
@@ -384,6 +401,16 @@
                 you can use these as a simple alternative. <b>attrnames</b> is an unordered list of
                 names of the attributes with which the cache was tagged; the language will be
                 selected based on the <b>langpref</b> parameter.
+            </li>
+            <li>
+                <p>%OKAPI:infotag:ocpl-specific% <b>oc_team_annotation</b> - HTML text containing OC team annotations
+                to the geocache listing. See the <b>oc_team_annotation</b> parameter for
+                more information.</p>
+                <p>Notices: The content of this field is not properly localized.
+                It will only partially respond to the <b>langpref</b> parameter and may
+                contain an arbitrary mixture of languages and differently localized data
+                (<a href='https://github.com/opencaching/okapi/issues/533'>why?</a>).
+                OCDE installations currently will always return an empty string.</p>
             </li>
             <li>
                 <p><b>attribution_note</b> - the proper attribution note for the cache listing according

--- a/okapi/services/caches/geocaches/WebService.php
+++ b/okapi/services/caches/geocaches/WebService.php
@@ -34,7 +34,7 @@ class WebService
         'is_ignored', 'willattends', 'country', 'state', 'preview_image',
         'trip_time', 'trip_distance', 'attribution_note','gc_code', 'hint2', 'hints2',
         'protection_areas', 'short_description', 'short_descriptions', 'needs_maintenance',
-        'watchers');
+        'watchers', 'oc_team_annotation');
 
     public static function call(OkapiRequest $request)
     {
@@ -66,17 +66,17 @@ class WebService
             if (!in_array($field, self::$valid_field_names))
                 throw new InvalidParam('fields', "'$field' is not a valid field code.");
 
-        # Some fields need to be temporarily included whenever the "description"
-        # or "attribution_note" field are included. That's a little ugly, but
-        # helps performance and conforms to the DRY rule.
+        # Some fields need to be temporarily included whenever a description-
+        # related field is included. That's a little ugly, but helps performance
+        # and conforms to the DRY rule.
 
-        $fields_to_remove_later = array('empty_descriptions');
+        $fields_to_remove_later = array();
         if (
             in_array('description', $fields) || in_array('descriptions', $fields)
             || in_array('short_description', $fields) || in_array('short_descriptions', $fields)
             || in_array('hint', $fields) || in_array('hints', $fields)
             || in_array('hint2', $fields) || in_array('hints2', $fields)
-            || in_array('attribution_note', $fields)
+            || in_array('attribution_note', $fields) || in_array('oc_team_annotation', $fields)
         )
         {
             if (!in_array('owner', $fields))
@@ -95,6 +95,13 @@ class WebService
         if (!$attribution_append) $attribution_append = 'full';
         if (!in_array($attribution_append, array('none', 'static', 'full')))
             throw new InvalidParam('attribution_append');
+
+        $oc_team_annotation = $request->get_parameter('oc_team_annotation');
+        if (!$oc_team_annotation) $oc_team_annotation = 'description';
+        if (!in_array($oc_team_annotation, array('description', 'separate')))
+            throw new InvalidParam('oc_team_annotation');
+        if ($oc_team_annotation == 'separate' && !in_array('oc_team_annotation', $fields))
+            $fields[] = 'oc_team_annotation';
 
         $user_uuid = $request->get_parameter('user_uuid');
         if ($user_uuid != null)
@@ -348,6 +355,7 @@ class WebService
                     case 'alt_wpts': /* handled separately */ break;
                     case 'country': /* handled separately */ break;
                     case 'state': /* handled separately */ break;
+                    case 'oc_team_annotation': /* handled separately */ break;
                     case 'last_found': $entry['last_found'] = ($row['last_found'] > '1980') ? date('c', strtotime($row['last_found'])) : null; break;
                     case 'last_modified': $entry['last_modified'] = date('c', strtotime($row['last_modified'])); break;
                     case 'date_created': $entry['date_created'] = date('c', strtotime($row['date_created'])); break;
@@ -506,7 +514,8 @@ class WebService
         if (in_array('description', $fields) || in_array('descriptions', $fields)
             || in_array('short_description', $fields) || in_array('short_descriptions', $fields)
             || in_array('hint', $fields) || in_array('hints', $fields)
-            || in_array('hint2', $fields) || in_array('hints2', $fields))
+            || in_array('hint2', $fields) || in_array('hints2', $fields)
+            || in_array('oc_team_annotation', $fields))
         {
             # At first, we will fill all those fields, even if user requested just one
             # of them. We will chop off the unwanted ones at the end.
@@ -518,12 +527,21 @@ class WebService
                 $result_ref['empty_descriptions'] = [];
                 $result_ref['hints'] = new ArrayObject();
                 $result_ref['hints2'] = new ArrayObject();
+                $result_ref['oc_team_annotations'] = new ArrayObject();
             }
+            $fields_to_remove_later[] = 'empty_descriptions';
+            $fields_to_remove_later[] = 'oc_team_annotations';
 
             # Get cache descriptions and hints.
 
+            if (Settings::get('OC_BRANCH') == 'oc.pl')
+                $oc_team_annotation_SQL = 'rr_comment';
+            else
+                $oc_team_annotation_SQL = "null";
             $rs = Db::query("
-                select cache_id, language, `desc`, short_desc, hint
+                select
+                    cache_id, language, `desc`, short_desc, hint,
+                    ".$oc_team_annotation_SQL." as oc_team_annotation
                 from cache_desc
                 where cache_id in ('".implode("','", array_map('\okapi\core\Db::escape_string', array_keys($cacheid2wptcode)))."')
             ");
@@ -539,7 +557,8 @@ class WebService
                 $language = strtolower($row['language']);
 
                 $listing_is_outdated = in_array($cache_code, $outdated_listings);
-                if ($row['desc'] || $listing_is_outdated)
+                $include_team_annotation = ($row['oc_team_annotation'] && $oc_team_annotation == 'description');
+                if ($row['desc'] || $listing_is_outdated || $include_team_annotation)
                 {
                     /* Note, that the "owner" and "internal_id" fields are automatically included,
                      * whenever the cache description is included. */
@@ -560,6 +579,24 @@ class WebService
                             $tmp
                         );
                         Okapi::gettext_domain_restore();
+                    }
+                    if ($include_team_annotation)
+                    {
+                        # Do some ugly hack so that annotations are readble without OC CSS:
+
+                        $formatted_team_annotation = str_replace(
+                            'class="ocTeamCommentHeader"',
+                            'class="ocTeamCommentHeader" style="display: block; padding-top: 0.5em;"',
+                            $row['oc_team_annotation']
+                        );
+                        $tmp = (
+                            '<div class="ocTeamCommentSection">'.
+                            "<b>"._("Annotations by the Opencaching team:")."</b><br />\n".
+                            $formatted_team_annotation.
+                            "<span style='display: block; padding-top: 0.5em'>("._("End of annotations").")</span>".
+                            "<hr /></div>\n" .
+                            $tmp
+                        );
                     }
                     if ($row['desc'] && $attribution_append != 'none')
                     {
@@ -586,9 +623,14 @@ class WebService
                     $results[$cache_code]['hints2'][$language]
                         = htmlspecialchars_decode(mb_ereg_replace("<br />", "" , $row['hint']), ENT_COMPAT);
                 }
+                if ($row['oc_team_annotation'])
+                {
+                    $results[$cache_code]['oc_team_annotations'][$language] = $row['oc_team_annotation'];
+                }
             }
             unset($listing_is_outdated);
             unset($language);
+            unset($include_team_annotation);
 
             foreach ($results as &$result_ref)
             {
@@ -604,13 +646,19 @@ class WebService
                 $result_ref['description'] = Okapi::pick_best_language($result_ref['descriptions'], $langprefs);
                 $result_ref['hint'] = Okapi::pick_best_language($result_ref['hints'], $langprefs);
                 $result_ref['hint2'] = Okapi::pick_best_language($result_ref['hints2'], $langprefs);
+
+                # OCPL currently stores the same team comments redundantly in all
+                # descriptions of the geocache. We might pick any of them. Probably
+                # they will be moved to the 'caches' table later (see issue #533).
+
+                $result_ref['oc_team_annotation'] = Okapi::pick_best_language($result_ref['oc_team_annotations'], $langprefs);
             }
 
             # Remove unwanted fields.
 
             foreach (array(
                 'short_description', 'short_descriptions', 'description', 'descriptions',
-                'hint', 'hints', 'hint2', 'hints2'
+                'hint', 'hints', 'hint2', 'hints2', 'oc_team_annotation',
             ) as $field)
                 if (!in_array($field, $fields))
                     foreach ($results as &$result_ref)


### PR DESCRIPTION
Interface considerations:
* Named it "annotation" instead of "comment" to distinguish from "OC team comment" type of log entries.
* Though the `rr_comment` field can contain _multiple_ entries, name the OKAPI field `oc_team_annotation` in singular to be consistent with fields like description/descriptions and hint/hints.
* Omit the corresponding plural language-array field `oc_team_annotations`, because OCPL website has no facility to associate languages with the annotations; content would be redundant for all languages.

Replication loose ends:
* Add `oc_team_annotation` field to replication. This should be done with a global update of replicated fields, because it's (one-time) very expensive. Also document how to hide the team annotations inside the descriptions.
* Okapi adds strings like "Annotations by the Opencaching team:", which will be replicated only in the site's default language. I think this is appropriate, as similar is true for the header strings of the annotations. 