### PR TITLE
Proposal for services/caches/capabilities and overhaul of cache type specs

### DIFF
--- a/okapi/core/Db.php
+++ b/okapi/core/Db.php
@@ -299,6 +299,8 @@ class Db
                 table_schema='".self::escape_string(Settings::get('DB_NAME'))."'
                 and table_name='".self::escape_string($table)."'
                 and column_name='".self::escape_string($field)."'
-        ");
+        ") + 0;
+        /* OC.DE installation returned a string here, OC.PL an integer.
+         * Added type cast. */
     }
 }

--- a/okapi/core/Okapi.php
+++ b/okapi/core/Okapi.php
@@ -917,47 +917,59 @@ class Okapi
     private static $cache_types = array(
         #
         # OKAPI does not expose type IDs. Instead, it uses the following
-        # "code words". Only the "primary" cache types are documented.
-        # This means that all other types may (in theory) be altered.
-        # Cache type may become "primary" ONLY when *all* OC servers recognize
-        # that type.
+        # "code words".
+        #
+        # IMPORTANT: For backward compatibility, cache types must never be
+        # removed from this table! If a type is discarded, assign it to [].
         #
         # Changing this may introduce nasty bugs (e.g. in the replicate module).
         # CONTACT ME BEFORE YOU MODIFY THIS!
         #
-        'oc.pl' => array(
-            # Primary types (documented, cannot change)
-            'Traditional' => 2, 'Multi' => 3, 'Quiz' => 7, 'Virtual' => 4,
-            'Event' => 6,
-            # Additional types (may get changed)
-            'Other' => 1, 'Webcam' => 5,
-            'Moving' => 8, 'Podcast' => 9, 'Own' => 10,
-        ),
-        'oc.de' => array(
-            # Primary types (documented, cannot change)
-            'Traditional' => 2, 'Multi' => 3, 'Quiz' => 7, 'Virtual' => 4,
-            'Event' => 6,
-            # Additional types (might get changed)
-            'Other' => 1, 'Webcam' => 5,
-            'Math/Physics' => 8, 'Moving' => 9, 'Drive-In' => 10,
-        )
+
+        # common types of all OC sites
+        'Traditional'  => ['oc.de' => 2, 'oc.pl' => 2],
+        'Multi'        => ['oc.de' => 3, 'oc.pl' => 3],
+        'Quiz'         => ['oc.de' => 7, 'oc.pl' => 7],
+        'Virtual'      => ['oc.de' => 4, 'oc.pl' => 4],
+        'Event'        => ['oc.de' => 6, 'oc.pl' => 6],
+        'Webcam'       => ['oc.de' => 5, 'oc.pl' => 5],
+        'Moving'       => ['oc.de' => 9, 'oc.pl' => 8],
+        'Other'        => ['oc.de' => 1, 'oc.pl' => 1],
+
+        # local types
+        'Podcast'      => ['oc.pl' => 9],
+        'Own'          => ['oc.pl' => 10],
+        'Math/Physics' => ['oc.de' => 8, 'mapto' => ['name' => 'Quiz', 'acodes' => ['A16']]],
+        'Drive-In'     => ['oc.de' => 10, 'mapto' => ['name' => 'Traditional', 'acodes' => ['A19']]],
     );
+
+    /** Return all types of this OC site which are exposed by OKAPI. **/
+    public static function get_local_okapi_cache_types()
+    {
+        static $local_types = [];
+        if (!$local_types)
+        {
+            $branch = Settings::get('OC_BRANCH');
+            foreach (self::$cache_types as $cache_type => $properties)
+                if (isset($properties[$branch]) && !isset($properties['mapto']))
+                    $local_types[] = $cache_type;
+        }
+        return $local_types;
+    }
+
+    /** Cache types that can be searched for. **/
+    public static function is_searchable_cache_type($name)
+    {
+        return isset(self::$cache_types[$name]);
+    }
 
     /** E.g. 'Traditional' => 2. For unknown names throw an Exception. */
     public static function cache_type_name2id($name)
     {
-        $ref = &self::$cache_types[Settings::get('OC_BRANCH')];
-        if (isset($ref[$name]))
-            return $ref[$name];
+        if (isset(self::$cache_types[$name][Settings::get('OC_BRANCH')]))
+            return self::$cache_types[$name][Settings::get('OC_BRANCH')];
         throw new \Exception("Method cache_type_name2id called with unsupported cache ".
-            "type name '$name'. You should not allow users to submit caches ".
-            "of non-primary type.");
-    }
-
-    public static function is_known_cache_type($name)
-    {
-        return array_key_exists($name, self::$cache_types['oc.pl']) ||
-               array_key_exists($name, self::$cache_types['oc.de']);
+            "type name '$name'.");
     }
 
     /** E.g. 2 => 'Traditional'. For unknown ids returns "Other". */
@@ -967,12 +979,39 @@ class Okapi
         if ($reversed == null)
         {
             $reversed = array();
-            foreach (self::$cache_types[Settings::get('OC_BRANCH')] as $key => $value)
-                $reversed[$value] = $key;
+            $branch = Settings::get('OC_BRANCH');
+            foreach (self::$cache_types as $name => $properties)
+                if (isset($properties[$branch]))
+                    $reversed[$properties[$branch]] = $name;
         }
         if (isset($reversed[$id]))
             return $reversed[$id];
         return "Other";
+    }
+
+    /** Map cache types which is not exposed by OKAPI to a common types. **/
+    public static function map_cache_type($mapfrom_type)
+    {
+        if (isset(self::$cache_types[$mapfrom_type]['mapto']))
+            return self::$cache_types[$mapfrom_type]['mapto'];
+        else
+            return ['name' => $mapfrom_type, 'acodes' => []];
+    }
+
+    /** Returns an array of cache types which are mapped to the given type. **/
+    public static function reverse_map_cache_type($mapto_type)
+    {
+        static $reversed = null;
+        if (!$reversed)
+        {
+            $reversed = array();
+            foreach (self::$cache_types as $name => $properties)
+                if (isset($properties['mapto']))
+                    $reversed[$properties['mapto']['name']][] = $name;
+        }
+        if (isset($reversed[$mapto_type]))
+            return $reversed[$mapto_type];
+        return [];
     }
 
     private static $cache_statuses = array(
@@ -1012,6 +1051,22 @@ class Okapi
         'xlarge' => 6,
         'other' => 1,
     );
+
+    public static function get_local_cache_sizes()
+    {
+        # OCPL only knows a subset of sizes, which is defined in the
+        # GeoCacheCommons class. OCDE supports all sizes; they are listed
+        # in the 'cache_size' table.
+
+        if (Settings::get('OC_BRANCH') == 'oc.pl')
+        {
+            return ['none', 'micro', 'small', 'regular', 'large', 'xlarge'];
+        }
+        else
+        {
+            return array_keys(self::$cache_sizes);
+        }
+    }
 
     /** E.g. 'micro' => 2. For unknown names throw an Exception. */
     public static function cache_size2_to_sizeid($size2)

--- a/okapi/core/OkapiServiceRunner.php
+++ b/okapi/core/OkapiServiceRunner.php
@@ -33,6 +33,7 @@ class OkapiServiceRunner
         'services/caches/search/by_urls',
         'services/caches/search/save',
         'services/caches/shortcuts/search_and_retrieve',
+        'services/caches/capabilities',
         'services/caches/edit',
         'services/caches/geocache',
         'services/caches/geocaches',

--- a/okapi/services/apisrv/installation/WebService.php
+++ b/okapi/services/apisrv/installation/WebService.php
@@ -30,7 +30,12 @@ class WebService
         $result['mobile_registration_url'] = Settings::get('MOBILE_REGISTRATION_URL');
         $result['image_max_upload_size'] = Settings::get('IMAGE_MAX_UPLOAD_SIZE');
         $result['image_rcmd_max_pixels'] = Settings::get('IMAGE_MAX_PIXEL_COUNT');
-        $result['geocache_passwd_max_length'] = Db::field_length('caches', 'logpw');
+
+        # Version 1623 added the 'geocache_passwd_max_length' field. It turned out
+        # to have wrong data type (string) only at OCDE. services/caches/edit had
+        # not be used until then at least at OCPL sites, and the OCDE field was
+        # buggy. So we removed it and added a new 'password_max_length' field with
+        # services/caches/capabilities.
 
         return Okapi::formatted_response($request, $result);
     }

--- a/okapi/services/apisrv/installation/docs.xml
+++ b/okapi/services/apisrv/installation/docs.xml
@@ -93,11 +93,6 @@
                 site to fit this restriction. Larger images may have been
                 uploaded in the past, or by other means than OKAPI.</p>
             </li>
-            <li>
-                <p><b>geocache_passwd_max_length</b> - the maximum length of
-                a password that will be accepted by
-                <a href='%OKAPI:methodargref:services/caches/edit%'>services/caches/edit</a>.</p>
-            </li>
         </ul>
     </returns>
 </xml>

--- a/okapi/services/caches/capabilities/WebService.php
+++ b/okapi/services/caches/capabilities/WebService.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace okapi\services\caches\capabilities;
+
+use okapi\core\Db;
+use okapi\core\Exception\InvalidParam;
+use okapi\core\Okapi;
+use okapi\core\Request\OkapiRequest;
+use okapi\Settings;
+
+class WebService
+{
+    public static function options()
+    {
+        return array(
+            'min_auth_level' => 1
+        );
+    }
+
+    public static function call(OkapiRequest $request)
+    {
+        $result = array();
+
+        $result['types'] = Okapi::get_local_okapi_cache_types();
+        $result['sizes'] = Okapi::get_local_cache_sizes();
+        $result['has_ratings'] = (Settings::get('OC_BRANCH') == 'oc.pl');
+        $result['password_max_length'] = Db::field_length('caches', 'logpw') + 0;
+
+        return Okapi::formatted_response($request, $result);
+    }
+}

--- a/okapi/services/caches/capabilities/docs.xml
+++ b/okapi/services/caches/capabilities/docs.xml
@@ -18,7 +18,7 @@
                 <p><b>types</b> - list of the cache types which are currently
                 available at this installation. See the
                 <a href='%OKAPI:methodargref:services/caches/geocache%'>services/caches/geocache</a>
-                for more information on cache types.</p>
+                method for more information on cache types.</p>
             </li>
             <li>
                 <p><b>sizes</b> - list of the cache sizes which are currently

--- a/okapi/services/caches/capabilities/docs.xml
+++ b/okapi/services/caches/capabilities/docs.xml
@@ -1,0 +1,40 @@
+<xml>
+    <brief>Get information on available geocache properties</brief>
+    <issue-id>TODO</issue-id>
+    <desc>
+        <p>This method tells which geocache properties are available at this
+        OKAPI installation.</p>
+        
+        <p>Using this method is mostly optional. You never need to know about
+        differences between OKAPI installations when searching for or
+        retrieving geocaches. But this method may help to improve user
+        interfaces, e.g. by hiding unnecessary search options.</p>
+    </desc>
+    <common-format-params/>
+    <returns>
+        <p>A dictionary of the following structure:</p>
+        <ul>
+            <li>
+                <p><b>types</b> - list of the cache types which are currently
+                available at this installation. See the
+                <a href='%OKAPI:methodargref:services/caches/geocache%'>services/caches/geocache</a>
+                for more information on cache types.</p>
+            </li>
+            <li>
+                <p><b>sizes</b> - list of the cache sizes which are currently
+                available at this installation.</p>
+            </li>
+            <li>
+                <p><b>has_ratings</b> - boolean, <b>true</b> if this installation
+                can store geocache quality ratings. OKAPI provides methods to
+                submit and retrieve ratings, and to search for geocaches by
+                rating.</p>
+            </li>
+            <li>
+                <p><b>password_max_length</b> - the maximum length of
+                a password that will be accepted by
+                <a href='%OKAPI:methodargref:services/caches/edit%'>services/caches/edit</a>.</p>
+            </li>
+        </ul>
+    </returns>
+</xml>

--- a/okapi/services/caches/edit/docs.xml
+++ b/okapi/services/caches/edit/docs.xml
@@ -14,7 +14,7 @@
         If you supply an empty string, the password will be cleared, i.e.
         the geocache will not require a log password.</p>
         <p>You may query the maximum accepted password length for the OC site by
-        <a href='%OKAPI:methodargref:services/apisrv/installation%'>services/apsrv/installation</a>.
+        <a href='%OKAPI:methodargref:services/caches/capabilities%'>services/caches/capabilities</a>.
         There may also be installation-dependent restrictions on which
         geocaches may have passwords. <b>success</b> will be <b>false</b> and
         an explanation message will be returned if a password is rejected.</p>

--- a/okapi/services/caches/geocache/docs.xml
+++ b/okapi/services/caches/geocache/docs.xml
@@ -127,24 +127,36 @@
                 (<i>lat</i> and <i>lon</i> are in full degrees with a dot as a decimal point),
             </li>
             <li>
-                <p><b>type</b> - cache type. This might be <b>pretty much everything</b>,
-                but there are some predefined types that you might want to treat
-                in a special way (separate icons etc.). Well-known types include:</p>
+                <p><b>type</b> - cache type, one of the type codes that are included
+                in the <b>types</b> field of
+                <a href='%OKAPI:methodargref:services/caches/capabilities%'>services/caches/capabilities</a>.
+                Currently there are eight types which are in use at all OKAPI
+                installations:</p>
                 <ul>
                     <li><b>Traditional</b>,</li>
                     <li><b>Multi</b>,</li>
-                    <li><b>Quiz</b>,</li>
-                    <li><b>Moving</b>,</li>
+                    <li><b>Quiz</b>, also known as "Mystery",</li>
+                    <li><b>Moving</b>, a geocache with changing coordinates,</li>
                     <li><b>Virtual</b>,</li>
                     <li><b>Webcam</b>,</li>
-                    <li><b>Event</b>,</li>
-                    <li><i>(any other value is valid too)</i></li>
+                    <li><b>Other</b>, also dubbed "unknown type"; allows OC users to
+                        create special caches which don't fit into the scheme of
+                        well-known types,</li>
+                    <li><b>Event</b>, a peculiar type of geocache which is NOT a geocache
+                at all, but it <b>is</b> stored as a geocache in OC database. Just keep
+                in mind, that in case of Event Caches, some fields may have a little
+                different meaning than you would tell by their name.</li>
                 </ul>
-                <p><b>Event</b> is a peculiar type of geocache which is NOT a geocache
-                at all, but it <b>is</b> stored as a geocache in OC database (this design
-                decision is as old as the OC network itself!). Just keep in mind, that
-                in case of Event Caches, some fields may have a little different meaning
-                than you would tell by their name.</p>
+                <p>More types are in use at some installations:</p>
+                <ul>
+                    <li><b>Own</b>, a moving geocache which is carried by the owner,</li>
+                    <li><b>Podcast</b>, a geocache with attached MP3 file(s). The MP3
+                    data so far is not accessible via OKAPI.</li>
+                </ul>
+                <p>There are even more types, but OKAPI maps them to common types
+                (and eventually some attributes), so you won't see them in OKAPI data.</p>
+                <p>OC sites and OKAPI may decide to add or remove types, so you MUST BE
+                prepared for any new type code.</p>
             </li>
             <li>
                 <p><b>status</b> - cache status. Valid cache status codes currently include:</p>
@@ -508,8 +520,8 @@
                 <p><b>Note:</b> This data is user-supplied and is not validated in
                 any way. Consider using external geocoding services instead. Also,
                 currently you have no way of knowing in which language it will appear
-                in (but it *may* start to vary on the value of your <b>langpref</b>
-                parameter in the future).</p>
+                in. Only some OKAPI installations will localize it by the
+                <b>langpref</b> parameter.</p>
             </li>
             <li>
                 <p><b>state</b> - name of the major subnational entity the cache

--- a/okapi/services/caches/geocache/docs.xml
+++ b/okapi/services/caches/geocache/docs.xml
@@ -143,20 +143,22 @@
                         create special caches which don't fit into the scheme of
                         well-known types,</li>
                     <li><b>Event</b>, a peculiar type of geocache which is NOT a geocache
-                at all, but it <b>is</b> stored as a geocache in OC database. Just keep
-                in mind, that in case of Event Caches, some fields may have a little
-                different meaning than you would tell by their name.</li>
+                        at all, but it <b>is</b> stored as a geocache in OC database. Just
+                        keep in mind, that in case of Event Caches, some fields may have
+                        a little different meaning than you would tell by their name.</li>
+                    <li>(Types may be added or removed. Your application MUST be
+                        prepared for any new types and may handle them as "Other".)</li>
                 </ul>
                 <p>More types are in use at some installations:</p>
                 <ul>
                     <li><b>Own</b>, a moving geocache which is carried by the owner,</li>
                     <li><b>Podcast</b>, a geocache with attached MP3 file(s). The MP3
-                    data so far is not accessible via OKAPI.</li>
+                    data is not accessible via OKAPI.</li>
+                    <li>(Types may be added or removed. Your application MUST be
+                        prepared for any new types and may handle them as "Other".)</li>
                 </ul>
                 <p>There are even more types, but OKAPI maps them to common types
                 (and eventually some attributes), so you won't see them in OKAPI data.</p>
-                <p>OC sites and OKAPI may decide to add or remove types, so you MUST BE
-                prepared for any new type code.</p>
             </li>
             <li>
                 <p><b>status</b> - cache status. Valid cache status codes currently include:</p>

--- a/okapi/services/caches/search/SearchAssistant.php
+++ b/okapi/services/caches/search/SearchAssistant.php
@@ -152,8 +152,10 @@ class SearchAssistant
                     if (!Okapi::is_searchable_cache_type($name))
                         throw new InvalidParam('type', "'$name' is not a valid cache type.");
 
-                    # Cache types not supported by THIS OC installation are accepted
-                    # but ignored here; see issue #220.
+                    # Cache types not supported by THIS OC installation are accepted,
+                    # but will no match any caches. We translate them to a dummy ID.
+
+                    $types[] = -999;
                 }
                 foreach (Okapi::reverse_map_cache_type($name) as $mapped_type)
                     $types[] = Okapi::cache_type_name2id($mapped_type);

--- a/okapi/services/caches/search/SearchAssistant.php
+++ b/okapi/services/caches/search/SearchAssistant.php
@@ -149,11 +149,14 @@ class SearchAssistant
                 }
                 catch (Exception $e)
                 {
-                    if (!Okapi::is_known_cache_type($name))
+                    if (!Okapi::is_searchable_cache_type($name))
                         throw new InvalidParam('type', "'$name' is not a valid cache type.");
+
                     # Cache types not supported by THIS OC installation are accepted
                     # but ignored here; see issue #220.
                 }
+                foreach (Okapi::reverse_map_cache_type($name) as $mapped_type)
+                    $types[] = Okapi::cache_type_name2id($mapped_type);
             }
             if (count($types) > 0)
                 $where_conds[] = "caches.type $operator ('".implode("','", array_map('\okapi\core\Db::escape_string', $types))."')";

--- a/okapi/services/caches/search/all/docs.xml
+++ b/okapi/services/caches/search/all/docs.xml
@@ -17,9 +17,10 @@
         </ul>
     </desc>
     <opt name='type'>
-        <p>Pipe-separated list of cache type codes. If given, the results will be limited
-        to the given cache types. For a list of cache type codes, see services/caches/geocache
-        method.</p>
+        <p>Pipe-separated list of cache type codes. If given, the results will be
+        limited to the given cache types. For a list of cache type codes, see
+        <a href='%OKAPI:methodargref:services/caches/geocache%'>services/caches/geocache</a>
+        <b>type</b> field.</p>
 
         <p><b>Notice:</b> If you want to include all cache types <b>except</b>
         the given ones, prepend your list with the "-" sign.</p>
@@ -27,7 +28,8 @@
     <opt name='status' default='Available'>
         <p>Pipe-separated list of status codes. Only caches matching any of the given
         statuses will included in the response. For a list of cache status codes, see
-        services/caches/geocache method.</p>
+        <a href='%OKAPI:methodargref:services/caches/geocache%'>services/caches/geocache</a>
+        method.</p>
     </opt>
     <opt name='owner_uuid'>
         <p>Pipe-separated list of user IDs. If given, the list of returned caches
@@ -88,8 +90,11 @@
         included. The codes are: 'none', 'nano', 'micro', 'small', 'regular',
         'large', 'xlarge', 'other'.</p>
 
-        <p><b>Note:</b> Not all OC servers use all of these. I.e. OCPL does not
-        have 'nano' nor 'other' caches (but it might have them in the future).</p>
+        <p><b>Note:</b> Not all OC servers use all of these. The <b>sizes</b>
+        field of <a href='%OKAPI:methodargref:services/caches/capabilities%'>services/caches/capabilities</a>
+        tells which types are currently available at this installation. You
+        may also search for sizes which are unavailable here; then the result
+        will be empty.</p>
 
         <p><b>Notice:</b> If you want to include all cache sizes <b>except</b>
         the given ones, prepend your list with the "-" sign.</p>
@@ -106,8 +111,10 @@
         "insufficiently rated" caches to be included, then append "|X" suffix
         to the value of this parameter (e.g. "3-5|X").</p>
 
-        <p><b>Notice:</b> Only OCPL-based Opencaching installations provide ratings for their
-        geocaches. On OCDE-based installations, this parameter will be ignored.</p>
+        <p><b>Notice:</b> Not all Opencaching installations provide ratings for their
+        geocaches. The <b>has_ratings</b> field of
+        <a href='%OKAPI:methodargref:services/caches/capabilities%'>services/caches/capabilities</a>
+        tells if ratings are available. If not, this parameter will be ignored.</p>
     </opt>
     <opt name='min_rcmds'>
         <p>There are two possible value-types for this argument:</p>
@@ -226,9 +233,10 @@
         <p>Boolean. If set to <b>true</b>, only caches which belong to at
         least one <b>active</b> geopath will be included.</p>
 
-        <p>Geopaths are sets of geocaches. Only some Opencaching sites
-        implement this feature (OCPL-branch). If this site does not implement
-        it, and you will set this parameter to <b>true</b>, then you will
+        <p>Geopaths are sets of geocaches. All of the caches need to be
+        found to complete the geopath. Only some Opencaching sites
+        implement this feature. If this site does not implement it, and
+        you will set this parameter to <b>true</b>, then you will
         <b>always</b> receive an empty result.</p>
 
         <p><b>Note:</b> The parameter name "powertrail_only" is historical.

--- a/okapi/services/caches/search/all/docs.xml
+++ b/okapi/services/caches/search/all/docs.xml
@@ -20,7 +20,8 @@
         <p>Pipe-separated list of cache type codes. If given, the results will be
         limited to the given cache types. For a list of cache type codes, see
         <a href='%OKAPI:methodargref:services/caches/geocache%'>services/caches/geocache</a>
-        <b>type</b> field.</p>
+        <b>type</b> field. If a type is removed from that list in a future OKAPI
+        version, you can still search for it (but no caches will be returned).</p>
 
         <p><b>Notice:</b> If you want to include all cache types <b>except</b>
         the given ones, prepend your list with the "-" sign.</p>


### PR DESCRIPTION
This change addresses issues #220 and #398. It builds on commit 
9b46a60.

* Add the fields `geocache_types`, `geocache_sizes` and `geocache_ratings` to `apisrv/installations`. This enables developers to dynamically adjust their user interface to OC site capabilities, especially when searching for caches.
* Give a clearer and firmer interface to available geocache types.

This proposal deviates from two original OKAPI paradigms: "OC sites have too many cache types by far", and "keep differences between OC branches out of the interface, if possible". So here is a request for comments.