### PR TITLE
Edit cache listings

### DIFF
--- a/okapi/Settings.php
+++ b/okapi/Settings.php
@@ -52,6 +52,12 @@ final class Settings
         'SITELANG' => "en",
 
         /**
+         * Some sites have even a list of language preferences, e.g. to
+         * initialize the language selection list when creating a new cache.
+         */
+        'SITELANGS' => null,
+
+        /**
          * If set, it will be passed to date_default_timezone_set.
          *
          * If your system is configured properly, then you are not required to
@@ -329,6 +335,8 @@ final class Settings
             $dict['SITE_LOGO'] = $dict['SITE_URL'] . 'okapi/static/oc_logo.png';
         if ($dict['JPEG_QUALITY'] < 50 || $dict['JPEG_QUALITY'] > 100)
             throw new Exception('JPEG_QUALITY must be between 50 and 100.');
+        if ($dict['SITELANGS'] === null)
+            $dict['SITELANGS'] = array($dict['SITELANG']);
 
         # The OKAPI code is only compatible with utf8 and utf8mb4 charsets.
         if (!in_array($dict['DB_CHARSET'], array('utf8', 'utf8mb4'))) {

--- a/okapi/lib/OCPLSignals.php
+++ b/okapi/lib/OCPLSignals.php
@@ -29,7 +29,7 @@ class OCPLSignals
     }
 
     /** update cache altutude after coords have changed **/
-    public static function cache_coords_changed($cache_id)
+    public static function cache_location_changed($cache_id)
     {
         if (Settings::get('OC_BRANCH') == 'oc.pl')
             self::create('cache-altitude', ['cache_id' => $cache_id]);

--- a/okapi/services/attrs/attribute/docs.xml
+++ b/okapi/services/attrs/attribute/docs.xml
@@ -123,10 +123,20 @@
                 <em>attrs=gc_ocde:attrs</em> option for more explanation.</p>
             </li>
             <li>
+                <p><b>incompatible_acodes</b> - list of A-codes which logically
+                contradict this attribute; e.g. A33 (parking area nearby) contradicts
+                A21 (long walk).</p>
+
+                <p>Note: The <b>attr_acodes</b> field of the services/caches/geocache
+                method may contain any combination of contradicting A-codes, because
+                OC sites do not (fully) validate them on input. Also, we cannot
+                guarantee that the provided list of incompatible A-codes is complete.</p>
+            </li>
+            <li>
                 <p><b>is_locally_used</b> - boolean, indicates if the attribute is <i>currently</i>
                 used by <i>this</i> Opencaching server. Or, to be more specific, <b>true</b>
                 means that the attribute can currently be included in the <b>attr_acodes</b> field
-                of the <b>geocache</b> method in this OKAPI installation.</p>
+                of the services/caches/geocache method in this OKAPI installation.</p>
 
                 <p>Note that this flag can change in time. Some attributes may get
                 introduced into other installations, whereas other attributes may
@@ -144,6 +154,11 @@
                 attributes. All these images come in various sizes and can change over time.
                 In other words, if you want to use this attribute, then you must always be
                 prepared to receive <b>null</b>, or an image of unexpected dimensions.</p>
+            </li>
+            <li>
+                <p><b>is_addable</b> - boolean, indicates if the attribute can be added to
+                geocaches; <b>false</b> if the attribute has been deprecated, i.e. it still
+                may be in use, but can no longer be added to caches.</p>
             </li>
             <li>
                 <p><b>is_discontinued</b> - boolean, indicates if the attribute is discontinued.

--- a/okapi/services/attrs/attribute_index/WebService.php
+++ b/okapi/services/attrs/attribute_index/WebService.php
@@ -57,6 +57,17 @@ class WebService
             );
             $results = OkapiServiceRunner::call('services/attrs/attributes',
                 new OkapiInternalRequest($request->consumer, $request->token, $params));
+
+            if ($only_locally_used && in_array('incompatible_acodes', explode('|', $fields)))
+            {
+                foreach ($results as $acode => &$attr_ref) {
+                    $incompatible_local = [];
+                    foreach ($attr_ref['incompatible_acodes'] as &$acode)
+                        if ($attrdict[$acode]['internal_id'] !== null)
+                            $incompatible_local[] = $acode;
+                    $attr_ref['incompatible_acodes'] = $incompatible_local;
+                }
+            }
         } else {
             $results = new ArrayObject();
         }

--- a/okapi/services/attrs/attributes/WebService.php
+++ b/okapi/services/attrs/attributes/WebService.php
@@ -21,7 +21,8 @@ class WebService
 
     private static $valid_field_names = array(
         'acode', 'name', 'names', 'description', 'descriptions', 'gc_equivs', 'gc_ocde_equiv',
-        'is_locally_used', 'is_deprecated', 'local_icon_url', 'is_discontinued'
+        'is_locally_used', 'is_deprecated', 'local_icon_url', 'is_addable', 'is_discontinued',
+        'incompatible_acodes',
     );
 
     public static function call(OkapiRequest $request)
@@ -83,7 +84,7 @@ class WebService
             # Fill some other fields (not kept in the cached attrdict).
 
             $attr['is_locally_used'] = ($attr['internal_id'] !== null);
-            $attr['is_deprecated'] = $attr['is_discontinued'];  // deprecated and undocumetned field, see issue 70
+            $attr['is_deprecated'] = $attr['is_discontinued'];  // deprecated and undocumented field, see issue 70
 
             # Add to results.
 

--- a/okapi/services/caches/capabilities/WebService.php
+++ b/okapi/services/caches/capabilities/WebService.php
@@ -2,6 +2,7 @@
 
 namespace okapi\services\caches\capabilities;
 
+use okapi\core\Cache;
 use okapi\core\Db;
 use okapi\core\Exception\InvalidParam;
 use okapi\core\Okapi;
@@ -18,12 +19,15 @@ class WebService
     }
 
     private static $valid_field_names = [
-        'types', 'sizes', 'statuses', 'has_ratings', 'password_max_length'
+        'types', 'sizes', 'statuses', 'has_ratings', 'languages', 'primary_languages',
+        'countries', 'regions', 'can_set_region', 'password_max_length'
     ];
 
     public static function call(OkapiRequest $request)
     {
-        $result = array();
+        $result = [];
+
+        # evaluate parameters
 
         $fields = $request->get_parameter('fields');
         if (!$fields) $fields = "types|sizes|statuses|has_ratings";
@@ -32,22 +36,212 @@ class WebService
             if (!in_array($field, self::$valid_field_names))
                 throw new InvalidParam('fields', "'$field' is not a valid field code.");
 
+        $langpref = $request->get_parameter('langpref');
+        if (!$langpref) $langpref = "en";
+        $langprefs = explode("|", $langpref);
+
+        $cache_type = $request->get_parameter('cache_type');
+        if ($cache_type !== null)
+            if (!in_array($cache_type, Okapi::get_local_cachetypes()))
+                throw new InvalidParam('type', "'".$cache_type."' is not a valid cache type identifier.");
+
+        # calculate results
+
         if (in_array('types', $fields)) {
             $result['types'] = Okapi::get_local_cachetypes();
         }
         if (in_array('sizes', $fields)) {
-            $result['sizes'] = Okapi::get_local_cachesizes();
-        }
-        if (in_array('statuses', $fields)) {
-            $result['statuses'] = Okapi::get_local_statuses();
+            $result['sizes'] = Okapi::get_local_cachesizes($cache_type);
         }
         if (in_array('has_ratings', $fields)) {
             $result['has_ratings'] = (Settings::get('OC_BRANCH') == 'oc.pl');
         }
+        if (in_array('languages', $fields)) {
+            $result['languages'] = self::get_cl_dict($langprefs, 'languages');
+        }
+        if (in_array('primary_languages', $fields)) {
+            $result['primary_languages'] = self::get_primary_languages();
+        }
+        if (in_array('countries', $fields)) {
+            $result['countries'] = self::get_cl_dict($langprefs, 'countries');
+        }
+        if (in_array('regions', $fields)) {
+            $result['regions'] = self::get_regions();
+        }
+        if (in_array('can_set_region', $fields)) {
+            $result['can_set_region'] = (Settings::get('OC_BRANCH') == 'oc.pl');
+        }
         if (in_array('password_max_length', $fields)) {
-            $result['password_max_length'] = Db::field_length('caches', 'logpw') + 0;
+            if (Settings::get('OC_BRANCH') == 'oc.pl' && $cache_type == 'Traditional')
+                $result['password_max_length'] = 0;
+            else
+                $result['password_max_length'] = Db::field_length('caches', 'logpw') + 0;
         }
 
+        # Done. Return the results.
+
         return Okapi::formatted_response($request, $result);
+    }
+
+    /**
+     * The 'countries' and 'languages' tables have basically the same
+     * structure, so we use this parametrized function to construct either
+     * the countries dictionary or the languages dictionary.
+     */
+    private static function get_cl_dict($langprefs, $dict_type)
+    {
+        static $dict = [];
+
+        $cache_key = 'cachecaps/'.$dict_type;
+        if (!isset($dict[$dict_type])) {
+            $dict[$dict_type] = Cache::get($cache_key);
+        }
+        if ($dict[$dict_type] === null)
+        {
+            $dict[$dict_type] = [];
+
+            $table_sql = $dict_type;
+            $field_sql = ($dict_type == 'languages' ? 'lower(short)' : 'short');
+
+            if (Settings::get('OC_BRANCH') == 'oc.pl')
+            {
+                $tmp = Db::select_all("
+                    select ".$field_sql." as lang, pl, en, nl
+                    from ".$table_sql."
+                ");
+                foreach ($tmp as $row)
+                    foreach (['en', 'nl', 'pl'] as $lang)
+                        $dict[$dict_type][$row['lang']][$lang] = $row[$lang];
+            }
+            else
+            {
+                $tmp = Db::select_all("
+                    select
+                        ".$field_sql." as lang,
+                        lower(sys_trans_text.lang) trans_lang,
+                        ifnull(sys_trans_text.text, ".$table_sql.".name) as name
+                    from ".$table_sql."
+                    left join sys_trans on ".$table_sql.".trans_id = sys_trans.id
+                    left join sys_trans_text on sys_trans.id = sys_trans_text.trans_id
+                ");
+                foreach ($tmp as $row) {
+                    $dict[$dict_type][$row['lang']][$row['trans_lang']] = $row['name'];
+                }
+            }
+            Cache::set($cache_key, $dict[$dict_type], 24 * 3600);
+        }
+
+        $localized_dict = [];
+        foreach ($dict[$dict_type] as $lang => $trans) {
+            $localized_dict[$lang] = Okapi::pick_best_language($trans, $langprefs);
+        }
+        asort($localized_dict);
+
+        return $localized_dict;
+    }
+
+    private static function get_primary_languages()
+    {
+        static $primary_langs = null;
+
+        $cache_key = 'cachecaps/primary_languages';
+        if ($primary_langs === null) {
+            $primary_langs = Cache::get($cache_key);
+        }
+        if ($primary_langs === null)
+        {
+            # We start with the configured language set of the OC site,
+            # then try to detect other significant languages.
+
+            $primary_langs = Settings::get('SITELANGS');
+
+            # Calculate statistics of the languages that are used by the most
+            # number of owners of active caches. As estimated from develsite,
+            # this query runs << 1 second on the largest site, OCDE.
+
+            $language_stats = Db::select_all("
+                select lower(language) as lang, count(distinct caches.user_id) as count
+                from cache_desc
+                join caches on caches.cache_id = cache_desc.cache_id
+                where caches.status = 1
+                and caches.node='".Db::escape_string(Settings::get('OC_NODE_ID'))."'
+                group by language
+                order by count desc, language
+            ");
+            $total_owners = 0;
+            foreach ($language_stats as $row) {
+                $total_owners += $row['count'];
+            }
+
+            # Do some educated guess of additional significant languages, based
+            # on anlaysis of OCDE and OCPL data and estimates for small OC sites.
+
+            if ($total_owners > 0) {
+                $threshold = floor(log($total_owners) - 1);
+                $primary_langs = [];
+                foreach ($language_stats as $row) {
+                    if ($row['count'] >= $threshold) {
+                        if (!in_array($row['lang'], $primary_langs)) { 
+                            $primary_langs[] = $row['lang'];
+                        }
+                    } else {
+                        break;
+                    }
+                }
+            }
+
+            # The more owners, the less volatile will the language statistics be.
+            # Therefore we calculate the cache timeout from the owner count.
+            #
+            # ~10.000 OCDE owners with active geocaches => ~1 month cache timeout
+
+            Cache::set($cache_key, $primary_langs, $total_owners * 250);
+        }
+        return $primary_langs;
+    }
+
+    private static function get_regions()
+    {
+        if (Settings::get('OC_BRANCH') == 'oc.pl')
+        {
+            # OCPL has one regional level, which is identical to NUTS level 3.
+            # This fast query is not worth caching.
+
+            $regions = Db::select_all("
+                select code, name
+                from nuts_codes nc
+                join countries c on c.short = left(nc.code,2)  /* filter out unknown countries */
+                where code like '____'
+                order by code
+            ");
+        }
+        else
+        {
+            # OCDE has two regional levels. The corresponding NUTS levels are
+            # selected by the countries.adm_display2 and adm_display3 values.
+
+            # But as long as we don't implement searching for regions, we don't
+            # need OCDE regions, so we return null.
+
+            return null;
+            /*
+            $regions = Db::select_all("
+                select nc.code, nc.name
+                from nuts_codes nc
+                join countries c on c.short = left(nc.code, 2)
+                where code like
+                    IF(c.adm_display2 = 4, '_____', IF(c.adm_display2 = 3, '____', '___'))
+                )
+                order by code
+            ");
+            */
+        }
+
+        $result  = [];
+        foreach ($regions as $r)
+            if (substr($r['code'], -1) != 'Z')      # In OCDE DB there are "...Z" dummy entries.
+                $result[substr($r['code'], 0, 2)][$r['code']] = $r['name'];
+
+        return $result;
     }
 }

--- a/okapi/services/caches/capabilities/docs.xml
+++ b/okapi/services/caches/capabilities/docs.xml
@@ -16,9 +16,19 @@
         <p>Pipe-separated list of field names which you are interested in.
         Selected fields will be included in the response. See below for the
         list of available fields.</p>
-        <p>(Why a fields option? Because fields like <i>countries</i> and
-        <i>languages</i> may be added, that return lots of data or are
-        expensive to calculate.)</p>
+    </opt>
+    <opt name='langpref' default='en'>
+        <p>Pipe-separated list of ISO 639-1 language codes. This indicates the
+        order of preference in which language will be chosen for the names in
+        fields <b>languages</b> and <b>countries</b>. Note that this option is
+        <i>ignored</i> for the <b>regions</b> field, which will always return
+        names in local language.</p>
+    </opt>
+    <opt name='cache_type'>
+        <p>One of the cache type indentifiers returned in the <b>types</b>
+        field by an earlier call to this method. If supplied, the
+        <b>sizes</b> and <b>password_max_length</b> return values will
+        reflect the capabilities for this type of cache.</p>
     </opt>
     <common-format-params/>
     <returns>
@@ -31,14 +41,17 @@
                 method for more information on cache types.</p>
             </li>
             <li>
-                <p><b>sizes</b> - list of the cache sizes which are currently
-                available at this installation.</p>
+                <p><b>sizes</b> - list of the  cache sizes which are currently
+                available at this installation [for the given <b>cache_type</b>].
+                Note that the returned identifiers correspond the <b>size2</b>
+                field of <a href='%OKAPI:methodargref:services/caches/geocache%'>services/caches/geocache</a>,
+                not the deprecated <span class='deprecated'><b>size</b></span> field.</p>
             </li>
             <li>
                 <p><b>statuses</b> - list of the cache statuses which are
                 currently available at this installation. See the
                 <a href='%OKAPI:methodargref:services/caches/geocache%'>services/caches/geocache</a>
-                method for more information on cache types.</p>
+                method for more information on cache statuses.</p>
             </li>
             <li>
                 <p><b>has_ratings</b> - boolean, <b>true</b> if this installation
@@ -47,9 +60,49 @@
                 method to find out if a given geocache can be rated.</p>
             </li>
             <li>
+                <p><b>languages</b> - a dictionary (language code => name) of
+                available languages for geocache descriptions and hints.</p>
+            </li>
+            <li>
+                <p><b>primary_languages</b> - a list of codes of the preferred or
+                mostly used languages at this OC site, ordered descending by
+                relevance.  You may suggest this set of languages first when your
+                user edits cache descriptions (we recommend to present them in
+                alphabetical order).</p>
+            </li>
+            <li>
+                <p><b>countries</b> - a dictionary (country code => name) of
+                countries that can be assigned to geocache listings.</p>
+            </li>
+            <!-- li>
+                <p><b>primary_countries</b> - a list of codes of the countries
+                that are primarily served by this installation, ordered
+                descending by relevance. You may suggest this set of countries
+                first when your user edits cache descriptions (we recommend to
+                present them in alphabetical order).</p>
+            </li -->
+            <li>
+                <p><b>regions</b> - a dictionary (country code => region) of
+                countries, each containing a dictionary (region code => name)
+                of regions that can be assigned to geocache listings. If
+                <b>can_set_region</b> is <b>false</b>, then the return value
+                currently is <b>null</b>, but this may change. Also, the
+                length of the codes (which currently is always 4 characters)
+                may change.</p>
+            </li>
+            <li>
+                <p><b>can_set_region</b> - boolean, <b>true</b> if
+                <a href='%OKAPI:methodargref:services/caches/edit%'>services/caches/edit</a>
+                will accept the <b>region</b> parameter. If <b>false</b>,
+                then this installation will automatically calculate regions
+                from the cache location.</p>
+            </li>
+            <li>
                 <p><b>password_max_length</b> - the maximum length of
                 a password that will be accepted by
-                <a href='%OKAPI:methodargref:services/caches/edit%'>services/caches/edit</a>.</p>
+                <a href='%OKAPI:methodargref:services/caches/edit%'>services/caches/edit</a>
+                [for the given <b>cache_type</b>]. The value <b>0</b> indicates
+                that no password can be set.</p>
             </li>
         </ul>
     </returns>

--- a/okapi/services/caches/edit/WebService.php
+++ b/okapi/services/caches/edit/WebService.php
@@ -11,8 +11,9 @@ use okapi\core\Exception\ParamMissing;
 use okapi\core\Request\OkapiRequest;
 use okapi\core\Request\OkapiInternalRequest;
 use okapi\core\OkapiServiceRunner;
+use okapi\lib\OCPLSignals;
 use okapi\Settings;
-
+use okapi\services\attrs\AttrHelper;
 
 class WebService
 {
@@ -26,28 +27,34 @@ class WebService
     public static function call(OkapiRequest $request)
     {
         $cache_code = $request->get_parameter('cache_code');
-        if ($cache_code == null)
+        if ($cache_code == null) {
             throw new ParamMissing('cache_code');
-        $geocache = OkapiServiceRunner::call(
+        }
+        $cache = OkapiServiceRunner::call(
             'services/caches/geocache',
             new OkapiInternalRequest(
                 $request->consumer,
                 $request->token,
-                array('cache_code' => $cache_code, 'fields' => 'internal_id|type|date_created')
+                array(
+                    'cache_code' => $cache_code,
+                    'langpref' => $request->get_parameter('language'),
+                    'fields' => 'internal_id|location|country_code|region_code|type|size2|difficulty|terrain|trip_time|trip_distance|attr_acodes|names|name|date_created|req_passwd|gc_code'
+                )
             )
         );
-        $internal_id_escaped = Db::escape_string($geocache['internal_id']);
-        $geocache_internal = Db::select_row("
-            select node, user_id from caches where cache_id='".$internal_id_escaped."'
+        $cache_internal_id_escaped = Db::escape_string($cache['internal_id']);
+        $cache_internal = Db::select_row("
+            select node, user_id from caches where cache_id='".$cache_internal_id_escaped."'
         ");
-        if ($geocache_internal['node'] != Settings::get('OC_NODE_ID')) {
+        if ($cache_internal['node'] != Settings::get('OC_NODE_ID')) {
             throw new Exception(
                 "This site's database contains the geocache '$cache_code' which has been"
                 . " imported from another OC node. OKAPI is not prepared for that."
             );
         }
-        if ($geocache_internal['user_id'] != $request->token->user_id)
-            throw new BadRequest("Only own caches may be edited.");
+        if ($cache_internal['user_id'] != $request->token->user_id) {
+            throw new InvalidParam('cache_code', "Only own caches may be edited.");
+        }
 
         $problems = [];
         $change_sqls_escaped = [];
@@ -59,40 +66,253 @@ class WebService
         Okapi::gettext_domain_init($langprefs);
         try
         {
-            /**
-             * Note on attributes:
-             *
-             * At OCDE there is the feature to deprecate attributes. This means
-             * that they are still displayed in geocaches and are retained when
-             * editing, but can no longer be added to geocaches (and no longer
-             * be searched for).
-             *
-             * Currently there are two deprecated OCDE attribs: Aircraft required
-             * (A75) and External listing (no A-code yet). When editing attributes
-             * is implemented in Okapi, developers will need to know which
-             * attribs are deprecated; so this may need some "deprecated" flag
-             * in attribute-definitions.xml and services/attrs/attributes.
-             * Depending on the implementation, an A-code for "External listing"
-             * may be needed.
-             */
+            # name
 
-            # passwd
-            $newpw = $request->get_parameter('passwd');
-            if ($newpw !== null)
+            $name = $request->get_parameter('name');
+            if ($name !== null) {
+                $old_name = $request->get_parameter('old_name');
+                if (!$old_name)
+                    throw new ParamMissing('old_name');
+                elseif (count($cache['names']) != 1)
+                    throw new Exception("Unexpected cache name count");
+                elseif ($old_name != $cache['name'])
+                    throw new InvalidParam('old_name', "'".$old_name."' does not match the cache name ('".$cache['name']."').");
+                elseif (trim($name) == '')
+                    $problems['name'] = _("The cache name must not be empty.");
+                elseif ($name != $cache['name'])
+                    $change_sqls_escaped[] = "name = '".Db::escape_string(trim($name))."'";
+            }
+
+            # type
+
+            $type = $request->get_parameter('type');
+            if ($type !== null) {
+                if (!in_array($type, Okapi::get_local_cachetypes()))
+                    throw new InvalidParam('type', "'".$type."' is not a valid cache type (at this OC site).");
+                elseif ($type != $cache['type'])
+                    $change_sqls_escaped[] = "type = ".Okapi::cache_type_name2id($type);
+            } else {
+                $type = $cache['type'];
+            }
+
+            # query capabilities -- DEPENDS ON TYPE
+
+            $capabilites_needed = [
+                'country_code' => ['countries', 'regions'],
+                'region_code' => ['countries', 'regions'],
+                'type' => ['sizes'],
+                'size2' => ['sizes'],
+                'description' => ['languages'],
+                'short_description' => ['languages'],
+                'hint2' => ['languages'],
+                'passwd' => ['password_max_length'],
+            ];
+            $cap_fields = [];
+            foreach ($request->get_all_parameters_including_unknown() as $param => $dummy) {
+                if (isset($capabilites_needed[$param]))
+                    foreach ($capabilites_needed[$param] as $field)
+                        $cap_fields[$field] = true;
+            }
+            $capabilities = OkapiServiceRunner::call(
+                'services/caches/capabilities',
+                new OkapiInternalRequest(
+                    $request->consumer,
+                    $request->token,
+                    [
+                        'cache_type' => $type,
+                        'langpref' => $langpref,
+                            # This determines the language for cache_location.adm1,
+                            # if the country is changed. It's weird to derive it from
+                            # the langpref, but 1. that's what OC code does, and 2.
+                            # the field is obsolete anyway; see comments below.
+                        'fields' => implode('|', array_keys($cap_fields))
+                    ]
+                )
+            );
+            unset($cap_fields);
+            unset($capabilites_needed);
+
+            # location
+
+            $location = $request->get_parameter('location');
+            $location_update = false;
+            if ($location !== null)
             {
-                $capabilities = OkapiServiceRunner::call(
-                    'services/caches/capabilities',
-                    new OkapiInternalRequest($request->consumer, $request->token, [])
-                );
-                if (strlen($newpw) > $capabilities['password_max_length']) {
-                    $problems['passwd'] = sprintf(
-                        _('The password must not be longer than %d characters.'),
-                        $capabilities['password_max_length']
-                    );
-                } elseif (
+                $coords = Okapi::parse_location($location);
+                if ($coords === null)
+                    throw new InvalidParam('location', "'".$location."' is no valid 'lat|lon' pair.");
+                elseif ($coords[0] < -90 || $coords[0] > 90)
+                    $problems['location'] = _("Latitude degrees must range between -90 and 90.");
+                elseif ($coords[1] < -180 || $coords[1] > 180)
+                    $problems['location'] = _("Longitude degrees must range between -180 and 180.");
+                else if ($coords[0] == 0 && $coords[1] == 0)
+                    $problems['location'] = _("Coordinates must not be 0/0.");   # common error
+                else {
+                    $old_coords = Okapi::parse_location($cache['location']);
+                    if ($coords != $old_coords) {
+                        $change_sqls_escaped[] = "
+                            latitude = ".Db::float_sql($coords[0]).",
+                            longitude = ".Db::float_sql($coords[1])."
+                        ";
+                        $location_update = true;
+                    }
+                }
+                unset($old_coords);
+                unset($coords);
+            }
+
+            # country and region
+
+            $country_or_region_change = false;
+
+            $country_code = $request->get_parameter('country_code');
+            if ($country_code !== null)
+            {
+                if ($country_code != $cache['country_code']) {
+                    if (!in_array($country_code, array_keys($capabilities['countries']))) {
+                        throw new InvalidParam('country', "'".$country_code."' is no valid country code.");
+                    }
+                    $change_sqls_escaped[] = "country = '".Db::escape_string($country_code)."'";
+                    $country_or_region_change = true;
+                }
+            }
+            else
+            {
+                $country_code = $cache['country_code'];
+            }
+
+            if (Settings::get('OC_BRANCH') == 'oc.pl')
+            {
+                $region_code = $request->get_parameter('region_code');
+                if ($region_code !== null)
+                {
+                    if ($region_code == 'null') {
+                        $region_code = null;
+                    } else if ($region_code != $cache['region_code']) {
+
+                        if (!isset($capabilities['regions'][substr($region_code, 0, 2)][$region_code]))
+                            throw new InvalidParam('region', "'".$region_code."' is no valid region code.");
+                        $effective_country_code =
+                            ($country_code !== null ? $country_code : $cache['country_code']);
+                        if (substr($region_code, 0, 2) != $effective_country_code) {
+                            throw new InvalidParam(
+                                'region',
+                                "'".$region_code."' is not a valid region code for this country."
+                            );
+                        }
+                    }
+                }
+                else
+                {
+                    $region_code = $cache['region_code'];
+
+                    # If the cache country is changed without providing a new region code,
+                    # then we either assign the sole region code for the country, or clear
+                    # the region.
+
+                    if ($country_code !== null && $country_code != $cache['country_code'])
+                    {
+                        if (isset($capabilities['regions'][$country_code])
+                            && count($capabilities['regions'][$country_code]) == 1
+                        ) {
+                            reset($capabilities['regions'][$country_code]);
+                            $region_code = key($capabilities['regions'][$country_code]);
+                        } else {
+                            $region_code = null;
+                        }
+                    }
+                }
+                if ($region_code !== $cache['region_code']) {
+                    $country_or_region_change = true;
+                }
+            }
+
+            # $country_code and $region_code now both have the correct values for
+            # storing them into the 'cache_location' table.
+
+            # size2 -- DEPENDS ON TYPE
+
+            $size2 = $request->get_parameter('size2');
+            if ($size2 !== null)
+            {
+                # We allow to confirm an existing size, even if it is no longer
+                # available for the cache's type. OC websites do the same.
+
+                if ($size2 != $cache['size2']) {
+                    if (!in_array($size2, Okapi::get_local_cachesizes()))
+                        throw new InvalidParam('size2', "'".$size2."' is not a valid cache size (at this OC site).");
+                    elseif (!in_array($size2, $capabilities['sizes']))
+                        $problems['size2'] = _("This size is not available for this type of cache.");
+                    else
+                        $change_sqls_escaped[] = "size = ".Okapi::cache_size2_to_sizeid($size2);
+                }
+            }
+            elseif ($type !== $cache['type'] && !in_array($cache['size2'], $capabilities['sizes']))
+            {
+                if (count($capabilities['sizes']) == 1) {
+                    # Enforce the only valid cache size after a type change.
+                    $change_sqls_escaped[] = "size = ".Okapi::cache_size2_to_sizeid($capabilities['sizes'][0]);
+                } else {
+                    $problems['type'] = _("Cache type does not match cache size.");
+                }
+            }
+
+            # difficulty, terrain
+
+            foreach (['difficulty', 'terrain'] as $property)
+            {
+                $tmp = $request->get_parameter($property);
+                if ($tmp !== null)
+                {
+                    if (!preg_match('/^[0-9](\.[05]0*)?$/', $tmp))
+                        throw new InvalidParam($property, "'".$tmp."' is not a valid ".$property." value");
+                    elseif (!in_array($tmp, [1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5]))
+                        throw new InvalidParam($property, "'".$tmp."' is not a valid ".$property." value");
+                    elseif (2 * $tmp != $cache[$property])
+                        $change_sqls_escaped[] = $property." = ".(2 * $tmp);
+                }
+            }
+
+            # trip_time, trip_distance
+
+            foreach (
+                ['trip_time' => 'search_time', 'trip_distance' => 'way_length']
+                as $property => $db_field_sql
+            ) {
+                $tmp = $request->get_parameter($property);
+                if ($tmp !== null)
+                {
+                    # OC websites can handle numbers >= 0.01 for both properties,
+                    # so we accept only those. Also impose some reasonable upper limit
+                    # (but retain higher values that were entered on the OC website).
+
+                    $max_value = max($cache[$property], $property == 'trip_time' ? 999 : 99999);
+
+                    if (!preg_match('/^(null|[0-9]+\.?[0-9]*)$/', $tmp)) {
+                        throw new InvalidParam($property, "'".$tmp."' is not a valid ".$property." value");
+                    } elseif ($tmp != 'null' && ($tmp < 0.01 || $tmp > $max_value)) {
+                        $problems[$property] = (
+                            $property == 'trip_time'
+                            ? sprintf(_("Invalid trip time; must range between 1 minute and %d hours."), $max_value)
+                            : sprintf(_("Invalid trip distance; must range between 0.01 and %d km."), $max_value)
+                        );
+                    } else {
+                        $change_sqls_escaped[] = $db_field_sql." = ".Db::float_sql($tmp + 0);  # 'null' => 0
+                    }
+                    unset($max_value);
+                }
+            }
+
+            # passwd -- DEPENDS ON TYPE
+
+            $passwd = $request->get_parameter('passwd');
+            if ($passwd !== null)
+            {
+                if (
+                    $passwd != '' &&
                     Settings::get('OC_BRANCH') == 'oc.pl' &&
-                    $geocache['type'] == 'Traditional' &&
-                    $geocache['date_created'] > '2010-06-18 20:03:18'
+                    $type == 'Traditional' &&
+                    $cache['date_created'] > '2010-06-18 20:03:18'
                 ) {
                     # We won't bother the user with the creation date thing here.
                     # The *current* rule is that OCPL sites do not allow tradi passwords.
@@ -102,14 +322,228 @@ class WebService
                         _('%s does not allow log passwords for traditional caches.'),
                         Okapi::get_normalized_site_name()
                     );
+                } elseif (strlen($passwd) > $capabilities['password_max_length']) {
+                    $problems['passwd'] = sprintf(_(
+                        'The password must not be longer than %d characters.'),
+                        $capabilities['password_max_length']
+                    );
                 } else {
-                    $oldpw = Db::select_value("select logpw from caches where cache_id='".$internal_id_escaped."'");
-                    if ($newpw != $oldpw)
-                        $change_sqls_escaped[] = "logpw = '".Db::escape_string($newpw)."'";
+                    # There are passwords in OC databases that only consist of space(s).
+                    # OCPL still allows to enter them. We retain those old passwords, but
+                    # will trim any new password.
+
+                    $oldpw = Db::select_value("select logpw from caches where cache_id='".$cache_internal_id_escaped."'");
+                    if ($passwd != $oldpw)
+                        $change_sqls_escaped[] = "logpw = '".Db::escape_string(trim($passwd))."'";
                     unset($oldpw);
                 }
+            } elseif (
+                $cache['req_passwd'] != '' &&
+                Settings::get('OC_BRANCH') == 'oc.pl' &&
+                $type != $cache['type'] && $type == 'Traditional'
+            ) {
+                $problems['type'] = sprintf(
+                    _('%s does not allow log passwords for traditional caches.'),
+                    Okapi::get_normalized_site_name()
+                ) . " "._("Please choose another cache type or remove the password.");
             }
-            unset($newpw);
+
+            # gc_code
+
+            $gc_code = $request->get_parameter('gc_code');
+            if ($gc_code !== null)
+            {
+                if ($gc_code == '') {
+                    throw new InvalidParam(
+                        'gc_code',
+                        "Must not be empty. Supply 'null' if you want to remove the GC code."
+                    );
+                }
+                if ($gc_code == 'null')
+                    $gc_code = '';
+
+                # Correct frequent misspelling.
+                $gc_code = str_replace('O', '0', $gc_code);
+
+                if (!preg_match('/^(|^GC[0-9A-HJKMNPQRTV-Z]{2,})$/', $gc_code))
+                    $problems['gc_code'] = _("Invalid GC code");
+                elseif ($gc_code != $cache['gc_code'])
+                    $change_sqls_escaped[] = "wp_gc = '".Db::escape_string($gc_code)."'";
+            }
+
+            # attr_acodes
+
+            # The add/remove logic ensures that we will not remove local attributes
+            # that are not available (yet) in OKAPI. It also prevents accidential
+            # deletions.
+
+            $acodes_to_remove = [];
+            $acodes_to_add = [];
+
+            $attr_acodes = $request->get_parameter('attr_acodes');
+            if ($attr_acodes)   # empty list is allowed
+            {
+                $attr_problems = [];
+                $available_acodes = OkapiServiceRunner::call(
+                    'services/attrs/attribute_index',
+                    new OkapiInternalRequest(
+                        $request->consumer,
+                        $request->token,
+                        [
+                            'fields' => 'name|is_addable|incompatible_acodes',
+                            'only_locally_used' => 'true',
+                            'langpref' => $langpref
+                        ]
+                    )
+                );
+                foreach (explode('|', $attr_acodes) as $acode)
+                {
+                    $remove = (substr($acode, 0, 1) == '-');
+                    if ($remove)
+                        $acode = substr($acode, 1);
+                    if (!isset($available_acodes[$acode]))
+                        throw new InvalidParam('attr_acodes', "'".$acode."' is not a valid A-code (at this OC site).");
+                    if ($remove)
+                        $acodes_to_remove[] = $acode;
+                    elseif ($available_acodes[$acode]['is_addable'])
+                        $acodes_to_add[] = $acode;
+                    else {
+                        $attr_problems[] = sprintf(
+                            _("The attribute '%s' can no longer be added to %s caches."),
+                            $available_acodes[$acode]['name'],
+                            Okapi::get_normalized_site_name()
+                        );
+                    }
+                }
+                unset($remove);
+                unset($acode);
+
+                # test for conflicting attributes
+
+                if ($tmp = array_intersect($acodes_to_remove, $acodes_to_add)) {
+                    throw new InvalidParam(
+                        'attr_acodes',
+                        "You tried to add AND remove the attribute(s) ".implode(' and ', $tmp)
+                    );
+                }
+                $effective_acodes = array_merge(
+                    array_diff($cache['attr_acodes'], $acodes_to_remove),
+                    $acodes_to_add
+                );
+                $already_warned = [];
+                foreach ($acodes_to_add as $acode)
+                    foreach ($available_acodes[$acode]['incompatible_acodes'] as $incompatible)
+                        if (in_array($incompatible, $effective_acodes) &&
+                            !isset($already_warned[$incompatible.$acode])
+                        ) {
+                            $attr_problems[] = sprintf(
+                                _("The attributes '%s' and '%s' contradict."),
+                                $available_acodes[$acode]['name'],
+                                $available_acodes[$incompatible]['name']
+                            );
+                            # Attribute incompatibility is mutual. Take care that we
+                            # don't inform the user *twice* for the same attribute pair:
+                            $already_warned[$acode.$incompatible] = true;
+                        }
+                unset($already_warned);
+                unset($effective_acodes);
+
+                if ($attr_problems) {
+                    $problems['attr_acodes'] = implode("\n", $attr_problems);
+                }
+                unset($attr_problems);
+            }
+
+            # TODO: Detect conflicting attribute/cachetype combinations.
+            # OC websites don't do it, but it would improve content quality.
+
+            # description, short_description and hint2
+
+            $description = $request->get_parameter('description');
+            $short_description = $request->get_parameter('short_description');
+            $hint2 = $request->get_parameter('hint2');
+            $desc_params_given = ($description !== null || $short_description !== null || $hint2 !== null);
+
+            if ($desc_params_given)
+            {
+                $language = $request->get_parameter('language');
+                if ($language === null)
+                    throw new ParamMissing('language');
+                if (!isset($capabilities['languages'][$language]))
+                    throw new InvalidParam('language', "'".$language."' is not a valid language code.");
+
+                # purify/trim/encode texts
+
+                if ($description != '') {
+                    list($description, $value_for_desc_html_field) = Okapi::purify_html($description);
+                } else {
+                    # This avoid to change null => '', and to make the assumption
+                    # purify_html('') == ''.
+
+                    list($dummy, $value_for_desc_html_field) = Okapi::purify_html('');
+                }
+                if ($short_description != '') {
+                    $short_description = preg_replace('/[\r\n\t]+/', ' ', $short_description);
+                    $short_description = trim($short_description);
+                }
+                if ($hint2 != '') {
+                    # Both OC branches store the hint as HTML with \r\n line breaks.
+
+                    $hint2 = htmlspecialchars(trim($hint2), ENT_COMPAT);
+                    $hint2 = preg_replace('~\R~u', "\r\n", $hint2);   # https://stackoverflow.com/questions/7836632
+                    $hint2 = nl2br($hint2);
+                }
+
+                # validate descriptions and hint
+
+                # We won't use information returned by services/caches/geocaches
+                # here, to avoid assumptions on how that method processes
+                # descriptions and hints.
+
+                $language_upper_escaped = Db::escape_string(strtoupper($language));
+                $is_new_language = !Db::select_value("
+                    select 1 from cache_desc
+                    where cache_id = '".$cache_internal_id_escaped."'
+                    and language ='".$language_upper_escaped."'
+                    limit 1
+                ");
+                if ($is_new_language)
+                {
+                    if ($description.$short_description.$hint2 == '')
+                    {
+                        # Return messages with priority in mostly used field.
+                        if ($description !== null)
+                            $problems['description'] = _("Please enter some text.");
+                        elseif ($hint2 !== null)
+                            $problems['hint2'] = _("Please enter some text.");
+                        else
+                            $problems['short_description'] = _("Please enter some text.");
+                    }
+                    elseif ($description == '')
+                    {
+                        # We don't allow to submit a translation only of short
+                        # description and/or hint, because OC websites users of
+                        # this language wouldn't notice that there also is a
+                        # full description. See also the method docs.
+
+                        if (Db::select_value("
+                            select 1 from cache_desc
+                            where cache_id = '".$cache_internal_id_escaped."'
+                            and trim(`desc`) != ''
+                            limit 1
+                        ")) {
+                            if ($short_description != '') {
+                                $problems['short_description'] = _(
+                                    "Please also translate the full description text, ".
+                                    "not just the short description."
+                                );
+                            } else {
+                                $problems['hint2'] = _("Please also translate the description.");
+                            }
+                        }
+                    }
+                }
+            }
 
             Okapi::gettext_domain_restore();
         }
@@ -120,12 +554,249 @@ class WebService
         }
 
         # save changes
-        if (count($problems) == 0 && count($change_sqls_escaped) > 0) {
-            Db::execute("
-                update caches
-                set " . implode(', ', $change_sqls_escaped) . ", last_modified=NOW()
-                where cache_id = '".$internal_id_escaped."'
-            ");
+
+        if (!$problems && ($change_sqls_escaped || $acodes_to_add || $acodes_to_remove || $desc_params_given || $country_or_region_change))
+        {
+            Db::execute("start transaction");
+
+            # description, short_description, hint2
+
+            if ($desc_params_given)
+            {
+                if ($is_new_language)
+                {
+                    # There is a slight chance that since calculation of $is_new_language,
+                    # a description of this language already was inserted - e.g. by an
+                    # erroneously double-submit. To be on the safe side, we recalculate
+                    # $is_new_language inside the transaction. Will go quick from DB
+                    # cache, if cache_desc table was not changed.
+
+                    $is_new_language = !Db::select_value("
+                        select 1 from cache_desc
+                        where cache_id = '".$cache_internal_id_escaped."'
+                        and language ='".$language_upper_escaped."'
+                        limit 1
+                    ");
+                    if (!$is_new_language)
+                    {
+                        # Probably a duplicate submission - ignore.
+                    }
+                    else
+                    {
+                        Db::execute("
+                            insert into cache_desc (
+                                uuid, node, cache_id, language,
+                                `desc`, desc_html, desc_htmledit, hint, short_desc,
+                                date_created, last_modified
+                            )
+                            values (
+                                '".Okapi::create_uuid()."',
+                                '".Db::escape_string(Settings::get('OC_NODE_ID'))."',
+                                '".$cache_internal_id_escaped."',
+                                '".$language_upper_escaped."',
+                                '".Db::escape_string($description)."',
+                                '".Db::escape_string($value_for_desc_html_field)."',
+                                '".Db::escape_string(Okapi::get_default_value_for_text_htmledit($request->token->user_id))."',
+                                '".Db::escape_string($hint2)."',
+                                '".Db::escape_string($short_description)."',
+                                now(),
+                                now()
+                            )
+                        ");
+                        $desc_internal_id = Db::last_insert_id();
+                        Db::execute("
+                            insert into okapi_submitted_objects (object_type, object_id, consumer_key)
+                            values (
+                                ".Okapi::OBJECT_TYPE_CACHE_DESCRIPTION.",
+                                '".Db::escape_string($desc_internal_id)."',
+                                '".Db::escape_string($request->consumer->key)."'
+                            )
+                        ");
+                        unset($desc_internal_id);
+                    }
+                }
+                else   # not a new language
+                {
+                    # We won't use information returned by services/caches/geocaches
+                    # here, to avoid assumptions on how that method processes
+                    # descriptions and hints.
+
+                    $is_only_language = Db::select_value("
+                        select count(*)
+                        from cache_desc
+                        where cache_id = '".$cache_internal_id_escaped."'
+                    ") <= 1;
+                    $old_desc = Db::select_row("
+                        select `desc`, short_desc, hint
+                        from cache_desc
+                        where cache_id = '".$cache_internal_id_escaped."'
+                        and language='".$language_upper_escaped."'
+                    ");
+                    if (!$is_only_language)
+                    {
+                        $effective_desc =
+                            $description !== null ? $description : trim($old_desc['desc']);
+                        $effective_short_desc =
+                            $short_description !== null ? $short_description : trim($old_desc['short_desc']);
+                        $effective_hint =
+                            $hint2 !== null ? $hint2 : trim($old_desc['hint']);
+                    }
+                    if (!$is_only_language
+                        && $effective_desc.$effective_short_desc.$effective_hint == ''
+                    ) {
+                        Db::execute("
+                            delete from cache_desc
+                            where cache_id = '".$cache_internal_id_escaped."'
+                            and language = '".$language_upper_escaped."'
+                        ");
+                    }
+                    else
+                    {
+                        $desc_change_sqls_escaped = [];
+                        if ($description !== null && $description != $old_desc['desc']) {
+                            $desc_change_sqls_escaped[] = "`desc` = '".Db::escape_string($description)."'";
+                        }
+                        if ($short_description !== null && $short_description != $old_desc['short_desc']) {
+                            $desc_change_sqls_escaped[] = "short_desc = '".Db::escape_string($short_description)."'";
+                        }
+                        if ($hint2 !== null && $hint2 != $old_desc['hint']) {
+                            $desc_change_sqls_escaped[] = "hint = '".Db::escape_string($hint2)."'";
+                        }
+                        if ($desc_change_sqls_escaped) {
+                            $desc_change_sqls_escaped[] = "last_modified = now()";
+                            Db::execute("
+                                update cache_desc
+                                set ".implode(", ", $desc_change_sqls_escaped)."
+                                where cache_id = '".$cache_internal_id_escaped."'
+                                and language = '".$language_upper_escaped."'
+                            ");
+                        }
+                        unset($desc_change_sqls_escaped);
+                    }
+                    unset($is_only_language);
+                    unset($old_desc);
+                    unset($effective_desc);
+                    unset($effective_short_desc);
+                    unset($effective_hint);
+                }
+
+                # Finally, update the cache's default language. OC sites use
+                # this language for GPX export. Note that OCDE has updated it
+                # via trigger, but only using one default language. We can do
+                # better (if OCDE provides a SITELANGS list; else we just
+                # repeat what the OCDE trigger did).
+
+                # The desc_languages field has been updated on both branches
+                # via trigger.
+
+                $cache_desclangs = Db::select_value("
+                    select desc_languages
+                    from caches
+                    where cache_id = '".$cache_internal_id_escaped."'
+                ");
+                $cache_default_desclang = substr($cache_desclangs, 0, 2);
+
+                foreach (Settings::get('SITELANGS') as $sitelang) {
+                    if (strpos($cache_desclangs, strtoupper($sitelang)) !== false) {
+                        $cache_default_desclang = strtoupper($sitelang);
+                        break;
+                    }
+                }
+                $change_sqls_escaped[] =
+                    "default_desclang = '".Db::escape_string($cache_default_desclang)."'";
+            }
+
+            # attr_acodes
+
+            if ($acodes_to_add || $acodes_to_remove)
+            {
+                $acode2id = AttrHelper::get_acode_to_internal_id_mapping();
+                foreach ($acodes_to_add as $acode) {
+                    Db::execute("
+                        insert ignore into caches_attributes (cache_id, attrib_id)
+                        values (
+                            '".$cache_internal_id_escaped."',
+                            '".Db::escape_string($acode2id[$acode])."'
+                        )
+                    ");
+                }
+                $ids_to_remove_escaped = [];
+                foreach ($acodes_to_remove as $acode) {
+                    $ids_to_remove_escaped[] = Db::escape_string($acode2id[$acode]);
+                }
+                if ($ids_to_remove_escaped) {
+                    Db::execute("
+                        delete from caches_attributes
+                        where cache_id = '".$cache_internal_id_escaped."'
+                        and attrib_id in ('".implode("','", $ids_to_remove_escaped)."')
+                    ");
+                }
+                unset($ids_to_remove_escaped);
+                unset($acode2id);
+            }
+
+            # country/region; OCDE calculates them by cronjob
+
+            if ($country_or_region_change && Settings::get('OC_BRANCH') == 'oc.pl')
+            {
+                # Note that the cache_location.adm1 value is obsolete.
+                # Both OCPL and OCDE websites correctly generate the name
+                # from code1.
+
+                # For the case that we are processing bad codes that were
+                # fetched from OC database and passed on, fallback to "?".
+
+                $code1_escaped = Db::escape_string($country_code);
+                $adm1_escaped = Db::escape_string(
+                    isset($capabilities['countries'][$country_code])
+                    ? $capabilities['countries'][$country_code] : "?"
+                );
+                if ($region_code === null) {
+                    $code3_escaped_quoted = 'null';
+                    $adm3_escaped_quoted = 'null';
+                } else {
+                    $code3_escaped_quoted = "'".Db::escape_string($region_code)."'";
+                    $adm3_escaped_quoted = "'".Db::escape_string(
+                        isset($capabilities['regions'][$country_code][$region_code])
+                        ? $capabilities['regions'][$country_code][$region_code] : "?"
+                    )."'";
+                }
+
+                Db::execute("
+                    insert into cache_location (
+                        cache_id, code1, adm1, code3, adm3
+                    ) values (
+                        '".$cache_internal_id_escaped."',
+                        '".$code1_escaped."',
+                        '".$adm1_escaped."',
+                        ".$code3_escaped_quoted.",
+                        ".$adm3_escaped_quoted."
+                    ) on duplicate key update
+                        code1 = '".$code1_escaped."',
+                        adm1 = '".$adm1_escaped."',
+                        code3 = ".$code3_escaped_quoted.",
+                        adm3 = ".$adm3_escaped_quoted."
+                ");
+            }
+
+            # other changes
+
+            if (Settings::get('OC_BRANCH') == 'oc.pl') {
+                $change_sqls_escaped[] = "last_modified = now()";
+                # OCDE does this via trigger
+            }
+            if ($change_sqls_escaped) {
+                Db::execute("
+                    update caches
+                    set ".implode(", ", $change_sqls_escaped)."
+                    where cache_id = '".$cache_internal_id_escaped."'
+                ");
+            }
+            if ($location_update) {
+                OCPLSignals::cache_location_changed($cache['internal_id']);
+            }
+
+            Db::execute("commit");
         }
 
         $result = ['success' => count($problems) == 0, 'messages' => $problems];

--- a/okapi/services/caches/edit/docs.xml
+++ b/okapi/services/caches/edit/docs.xml
@@ -1,16 +1,148 @@
 <xml>
-    <brief>Change the properties of a geocache</brief>
+    <brief>Edit an existing geocache listing</brief>
     <issue-id>510</issue-id>
     <desc>
-        <p>This method allows your users to change properties of an owned
-        geocache. Currently, only the log password can be changed.
-        Let us know if you need to edit other geocache properties.</p>
+        <p>This method allows your user to change the contents of an owned
+        geocache listing. Please note that you won't be able to use this
+        method until you learn to handle OAuth.</p>
+
+        <p>Note: Some OCPL-based sites support only BMP (Basic Multilingual Plane) Unicode
+        characters for textual content. If you submit characters from outside of
+        the BMP plane (known as "supplementary planes", they include characters such
+        as smiley symbols), then keep in mind that texts might be saved garbled.</p>
     </desc>
     <req name='cache_code'>
         <p>Code of the geocache.</p>
     </req>
+    <opt name='name'>
+        <p>New name of the cache. The old name to be replaced must be supplied
+        as <b>old_name</b>.</p>
+    </opt>
+    <opt name='old_name'>
+        <p>The old cache name to be replaced.</p>
+        <p><b>Note</b>: This argument is needed for forward compatibility with
+        multilanguage cache names. If the supplied string does not match any
+        existing name of the cache, you will receive an HTTP 400 error response.</p>
+    </opt>
+    <opt name='location'>
+        <p>New coordinates of the cache in the "lat|lon" format (<i>lat</i> and
+        <i>lon</i> are in full degrees with a dot as a decimal point).</p>
+
+        <p><b>Note:</b> If you allow your user to freely edit the cache
+        location, then you MUST also allow to edit the country and region
+        (see below).</p>
+
+        <p><b>Note:</b> Most OC installations calculate additional information
+        from the cache coordinates, like altitude or region. These calculations
+        will usually be done some minutes after the location change (by
+        cronjob).</p>
+    </opt>
+    <opt name='country_code'>
+        <p>The country where the cache is located; one of the country codes
+        listed in the <b>countries</b> field of
+        <a href='%OKAPI:methodargref:services/caches/capabilities%'>services/caches/capabilities</a>.</p>
+    </opt>
+    <opt name='region_code' infotags='ocpl-specific'>
+        <p>The region where the cache is located; one of the region codes
+        of the cache's country that are listed in the <b>regions</b> field of
+        <a href='%OKAPI:methodargref:services/caches/capabilities%'>services/caches/capabilities</a>
+        (if any), or <b>null</b> for "no region specified".</p>
+        <p><b>Note:</b> Some installations will automatically calculate the
+        region frome cache coordinates (usually with some minutes delay).
+        These installations will <i>ignore</i> the <b>region_code</b> parameter.
+        You can detect those installations by the <b>can_set_region</b>
+        field of
+        <a href='%OKAPI:methodargref:services/caches/capabilities%'>services/caches/capabilities</a>
+        being <b>false</b>.</p>
+    </opt>
+    <opt name='type'>
+        <p>New type of the cache; one of the identifiers listed in the <b>types</b>
+        field of <a href='%OKAPI:methodargref:services/caches/capabilities%'>services/caches/capabilities</a>.</p>
+    </opt>
+    <opt name='size2'>
+        <p>New size of the cache; one of the identifiers listed in the <b>sizes</b>
+        field of <a href='%OKAPI:methodargref:services/caches/capabilities%'>services/caches/capabilities</a>.</p>
+    </opt>
+    <opt name='difficulty'>
+        <p>New difficulty estimation for the cache; a multiple of 0.5 in the
+        range from <b>1</b> to <b>5</b>.</p>
+    </opt>
+    <opt name='terrain'>
+        <p>New terrain estimation for the cache; a multiple of 0.5 in the
+        range from <b>1</b> to <b>5</b>.</p>
+    </opt>
+    <opt name='trip_time'>
+        <p>New estimation for the total time needed to find the cache, in hours
+        (&gt;= 1 minute); this will usually include the time to reach the cache
+        location <i>and</i> go back (from/to a parking spot, etc.); or <b>null</b>
+        for "unspecified".</p>
+    </opt>
+    <opt name='trip_distance'>
+        <p>New estimation for the total distance needed to find the cache, in
+        kilometers (&gt;= 0.01); this will usually include the time to reach the
+        cache location <i>and</i> go back (from/to a parking spot, etc.); or
+        <b>null</b> for "unspecified".</p>
+    </opt>
+    <opt name='attr_acodes'>
+        <p>A pipe-separated list of A-codes to be added to or removed from
+        the cache's attribute set. A-codes with a prepended minus (-)
+        will be removed instead of added. If you try to add and remove the
+        same attribute, you will receive an HTTP 400 error response.</p>
+        <p>Call the
+        <a href='%OKAPI:methodargref:services/attrs/attribute_index%'>services/attrs/attribute_index</a>
+        method with <b>only_locally_used</b>=<b>true</b> to obtain a list of
+        available A-codes. You may want to request the <b>incompatible_acodes</b>
+        field and avoid to submit conflicting A-codes. (They would yield a
+        <b>success</b>=<b>false</b> response.)</p>
+    </opt>
+    <opt name='description'>
+        <p>HTML string, new description ("long description") of the cache.
+        The language of the description must be supplied as <b>language</b>
+        argument. If a description for this language already exists, it will
+        be replaced; else a new description will be added.</p>
+
+        <p><b>Note:</b> If you want to "remove a language" from the cache,
+        submit an empty <b>description</b> <i>and</i> <b>short_description</b>
+        <i>and</i> <b>hint2</b> for that language.</p>
+    </opt>
+    <opt name='short_description'>
+        <p>A plaintext string with a new single line (very short) description
+        of the cache (kind of a "tagline text"). The language of the short
+        description must be supplied as <b>language</b> argument. If a short
+        description for this language already exists, it will be replaced;
+        else a new short description will be added.</p>
+
+        <p><b>Note:</b> When submitting a short description in a completely
+        new language (there is no long description, short description or
+        hint in that language for this cache), while a long description
+        exists in another language, then the same request should also include
+        a non-empty <b>description</b>. This prevents that OC website users
+        of the new language won't notice that there also is a long description.
+        If the <b>description</b> text is missing in this case, OKAPI will
+        return <b>success</b>=<b>false</b> and a message that prompts the user
+        to also provide a translation of the full description.</p>
+    </opt>
+    <opt name='hint2'>
+        <p>A plaintext, optional multiline string of cache hints/spoilers;
+        will usually be ROT13-encoded for display. The language of the hint
+        must be supplied as <b>language</b> argument. If a hint for this
+        language already exists, it will be replaced; else a new hint will
+        be added.</p>
+        <p>See the note for <b>short_description</b>; it's the same for the
+        hint.</p>
+    </opt>
+    <opt name='language'>
+        <p>The language of the given <b>short_description</b>, <b>description</b>
+        and <b>hint2</b> texts; one of the language codes as returned in the
+        <b>languages</b> field of
+        <a href='%OKAPI:methodargref:services/caches/capabilities%'>services/caches/capabilities</a>.</p>
+
+        <p><b>Note:</b> If you need to edit descriptions, short descriptions
+        or hints in multiple languages, then you will have to call this method
+        multiple times, once for each language.</p>
+    </opt>
     <opt name='passwd'>
-        <p>The new password for 'Found it' or 'Attended' log entries.
+        <p>A new password for 'Found it' or 'Attended' log entries.
         If you supply an empty string, the password will be cleared, i.e.
         the geocache will not require a log password.</p>
         <p>You may query the maximum accepted password length for the OC site by
@@ -18,6 +150,10 @@
         There may also be installation-dependent restrictions on which
         geocaches may have passwords. <b>success</b> will be <b>false</b> and
         an explanation message will be returned if a password is rejected.</p>
+    </opt>
+    <opt name='gc_code'>
+        <p>A Geocaching.com code (GC code) to be assigned with this OC
+        listing, or <b>null</b> for "unspecified".</p>
     </opt>
     <opt name='langpref' default='en'>
         <p>Pipe-separated list of ISO 639-1 language codes. This indicates the
@@ -33,18 +169,25 @@
                 <ul>
                     <li><b>true</b> if all of the supplied geocache properties
                     were saved successfully or if no property to be changed was
-                    supplied. The geocache's <b>last_modified</b> date has been
-                    updated if any property was changed,</li>
+                    supplied,</li>
+
                     <li><b>false</b> if nothing was saved, which means that at
-                    least one of the supplied parameters was not acceptable.</li>
+                    least one of the supplied parameters was logically invalid.
+                    E.g. the size "micro" was supplied for a type of cache
+                    which does not have a container.</li>
                 </ul>
             </li>
             <li>
-                <p><b>messages</b> - a dictionary of the supplied parameters
-                that were not acceptable, each entry giving a plain-text string
-                that explains the reason of rejection. The dictionary is empty
-                in case of success.</p>
+                <p><b>messages</b> - a dictionary (name => message) of the
+                supplied parameters that were not acceptable, each entry
+                giving a plain-text string that explains the reason of
+                rejection. Each of the strings may be multiline, separated
+                with newlines (\n). The dictionary is empty in case of
+                success.</p>
             </li>
         </ul>
+        <p>The method responds with an HTTP 400 error if parameters were
+        formally invalid, e.g. an undefinied attribute ID or cache size
+        was submitted.</p>
     </returns>
 </xml>

--- a/okapi/services/caches/geocache/docs.xml
+++ b/okapi/services/caches/geocache/docs.xml
@@ -19,6 +19,12 @@
         <p>Pipe-separated list of field names which you are interested with.
         Selected fields will be included in the response. See below for the
         list of available fields.</p>
+        <p>Alternatively, the phrase <b>for editing</b> (instead of a field
+        list) will include all fields that are editable by
+        <a href='%OKAPI:methodargref:services/caches/edit%'>services/caches/edit</a>.
+        It will also adjust the contents of the <b>descriptions</b> field
+        to be editable. Note the <b>for editing</b> is only available
+        through Level 3 Authentication for the owner of the cache,</p>
     </opt>
     <opt name='attribution_append' default='full'>
         <p>By default, OKAPI appends the value of <b>attribution_note</b> field to all the
@@ -386,7 +392,10 @@
             </li>
             <li>
                 <b>descriptions</b> - a dictionary (language code =&gt;
-                <a href='%OKAPI:docurl:html%'>HTML string</a>) of cache descriptions,
+                <a href='%OKAPI:docurl:html%'>HTML string</a>) of cache descriptions.
+                They will include the same additional notices as the <b>description</b>
+                field, unless the option <b>fields</b>=<b>for editing</b> is supplied,
+                which will <i>exclude</i> any additional notices,
             </li>
             <li class="deprecated">
                 <b>hint</b> - <a href='%OKAPI:docurl:html%'>HTML-encoded</a>
@@ -562,6 +571,15 @@
                 <p><b>Note:</b> This data is user-supplied and is not validated in
                 any way. Consider using external geocoding services instead.</p>
             </li>
+            <li>
+                <p><b>country_code</b> - an identifier of the country the cache is
+                placed in, or <b>null</b> if the country is unknown. The country
+                code  is provided only for
+                <a href='%OKAPI:methodargref:services/caches/edit%'>editing</a>
+                the cache's country, and it is only valid on the OC installation
+                that returned it (other installations may use other codes for
+                the same country.)</p>
+            </li>
             <li class='deprecated'>
                 <p><b>state</b> - deprecated; same as <b>region</b>, but <b>null</b>
                 may be returned instead of an empty string if the region is unknown.
@@ -582,6 +600,15 @@
                 currently you have no way of knowing in which language it will appear
                 in (but it *may* start to vary on the value of your <b>langpref</b>
                 parameter in the future).</p>
+            </li>
+            <li>
+                <p><b>region_code</b> - an identifier of the major subnational entity
+                the cache is placed in, or <b>null</b> if the entitiy is unknown.
+                The region code is provided only for
+                <a href='%OKAPI:methodargref:services/caches/edit%'>editing</a> the
+                cache's region, and it is only valid for the OC installation that
+                returned it (other installations may use other codes for the same
+                region).</p>
             </li>
             <li>
                 <p><b>protection_areas</b> - list of dictionaries, each representing a

--- a/okapi/services/logs/LogsCommon.php
+++ b/okapi/services/logs/LogsCommon.php
@@ -16,7 +16,6 @@ use okapi\core\OkapiServiceRunner;
 use okapi\core\Request\OkapiInternalRequest;
 use okapi\lib\OCPLSignals;
 use okapi\Settings;
-use Utils\Text\UserInputFilter; // OCPL specific
 
 /**
  * IMPORTANT: The "logging policy" logic - which logs are allowed under
@@ -207,25 +206,9 @@ class LogsCommon
             # additional HTML purification prior to the insertion into the
             # database.
 
-            # NOTICE: For both branches, we are including EXTERNAL OCDE
-            # libraries here! This code does not belong to OKAPI!
-
-            if (Settings::get('OC_BRANCH') == 'oc.de')
-            {
-                $opt['html_purifier'] = Settings::get('OCDE_HTML_PURIFIER_SETTINGS');
-
-                $purifier = new \OcHTMLPurifier($opt);
-                $formatted_comment = $purifier->purify($formatted_comment);
-
-                $value_for_text_html_field = 1;
-            }
-            else
-            {
-                $formatted_comment = UserInputFilter::purifyHtmlString($formatted_comment);
-
-                # see https://github.com/opencaching/opencaching-pl/pull/1224
-                $value_for_text_html_field = 2;
-            }
+            list($formatted_comment, $value_for_text_html_field) = Okapi::purify_html(
+                $formatted_comment
+            );
         }
 
         return [$formatted_comment, $value_for_text_html_field];

--- a/okapi/services/logs/submit/WebService.php
+++ b/okapi/services/logs/submit/WebService.php
@@ -436,15 +436,8 @@ class WebService
         # Finally! Insert the rows into the log entries table. Update
         # cache stats and user stats.
 
-        if (Settings::get('OC_BRANCH') == 'oc.de') {
-            $value_for_text_htmledit_field = Db::select_value("
-                select if(no_htmledit_flag, 0, 1)
-                from user
-                where user_id='".Db::escape_string($user['internal_id'])."'
-            ");
-        } else {
-            $value_for_text_htmledit_field = 1;
-        }
+        $value_for_text_htmledit_field
+            = Okapi::get_default_value_for_text_htmledit($user['internal_id']);
 
         $log_uuids = array(
             self::insert_log_row(


### PR DESCRIPTION
This is work in progress for an update of `services/caches/edit`. As it is a BIG update, I put it here for the case there are comments / suggestions on the interface or implementation.

* Includes new options/fields for `services/caches/edit` , `services/caches/capabilities` and `services/attrs/attribute`.
* Todo: Add an option to `services/caches/geocache` to exclude the OCDE "listing is outdated" notice from the description - important for editing descriptions.
* Todo: Add edit options for country, region, additional waypoints and images.