### PR TITLE
Fix attr_acodes formatting

### DIFF
--- a/okapi/services/caches/geocaches/WebService.php
+++ b/okapi/services/caches/geocaches/WebService.php
@@ -939,7 +939,7 @@ class WebService
             # Type mapping can have created duplicate acodes. Remove them.
 
             foreach ($results as &$result_ref) {
-                $result_ref['attr_acodes'] = array_unique($result_ref['attr_acodes']);
+                $result_ref['attr_acodes'] = array_values(array_unique($result_ref['attr_acodes']));
             }
 
             # Now, each cache object has a list of its acodes. We can get


### PR DESCRIPTION
If an attribute is removed in the middle if the attr_acodes array - the json output will be slightly different. This pr fix this behaviour. For more Information please have a look into https://github.com/cgeo/cgeo/issues/7437