### PR TITLE
A parameter awarded_status added to cache search filter

### DIFF
--- a/okapi/services/caches/search/SearchAssistant.php
+++ b/okapi/services/caches/search/SearchAssistant.php
@@ -678,6 +678,25 @@ class SearchAssistant
         unset($powertrail_ids, $join_powertrails);
 
         #
+        # awarded_status
+        # (uses cache_titled table existing in OCPL only)
+        #
+
+        if ($tmp = $this->request->get_parameter('awarded_status'))
+        {
+            if (!in_array($tmp, array('awarded_only', 'notawarded_only', 'either')))
+                throw new InvalidParam('awarded_status', "'$tmp'");
+            if (Settings::get('OC_BRANCH') == 'oc.pl') {
+                if ($tmp == "awarded_only") {
+                    $extra_joins[] = "join cache_titled on caches.cache_id = cache_titled.cache_id";
+                } elseif ($tmp == "notawarded_only") {
+                    $extra_joins[] = "left join cache_titled on caches.cache_id = cache_titled.cache_id";
+                    $where_conds[] = "cache_titled.cache_id is null";
+                }
+            }
+        }
+
+        #
         # set_and
         #
 

--- a/okapi/services/caches/search/SearchAssistant.php
+++ b/okapi/services/caches/search/SearchAssistant.php
@@ -692,8 +692,6 @@ class SearchAssistant
                     $awarded = false;
                     $field = substr($field, 1);
                 }
-                elseif ($field[0] == '+')
-                    $field = substr($field, 1); # ignore leading "+"
 
                 # reimplement this if as f.ex. 'switch' in case of another awards
                 if ($field == 'cotp') {

--- a/okapi/services/caches/search/all/docs.xml
+++ b/okapi/services/caches/search/all/docs.xml
@@ -262,19 +262,20 @@
         IDs. You should not use them. This parameter was implemented for
         internal use.</p>
     </opt>
-    <opt name='awarded_status' default='either'>
-        <p>Includes information about a "cache of the week/month etc." award
-        granted or not in the search criteria. Only some Opencaching sites
-        implement this feature. If you set the parameter to one of the following
-        values and this site does not implement it, it will not affect the
-        search result.</p>
+    <opt name='awarded'>
+        <p>Pipe separated list of award types. If given and not empty, an award
+        of selected type is added to filter constraints if it is applicable to
+        current Opencaching site. If a '-' character precedes the award type,
+        only caches <b>not granted</b> corresponding award will be included
+        in the resulting set. If a '+' character precedes the award type or
+        there is no preceding character, only caches <b>granted</b>
+        corresponding award will be included in the resulting set.</p>
 
-        <p>Should be one of the following:</p>
+        <p>The following award types are supported:</p>
         <ul>
-            <li><b>awarded_only</b> - only awarded caches will be returned,</li>
-            <li><b>notawarded_only</b> - only <b>not</b> awarded caches will be
-                returned,</li>
-            <li><b>either</b> - all caches will be returned.</li>
+            <li><b>cotp</b> - the Cache of the Period (week/month etc.) award.
+            Only some Opencaching sites implement this award and the period
+            depends on the particular site settings.</li>
         </ul>
     </opt>
     <opt name='set_and'>

--- a/okapi/services/caches/search/all/docs.xml
+++ b/okapi/services/caches/search/all/docs.xml
@@ -267,9 +267,8 @@
         of selected type is added to filter constraints if it is applicable to
         current Opencaching site. If a '-' character precedes the award type,
         only caches <b>not granted</b> corresponding award will be included
-        in the resulting set. If a '+' character precedes the award type or
-        there is no preceding character, only caches <b>granted</b>
-        corresponding award will be included in the resulting set.</p>
+        in the resulting set, otherwise only caches <b>granted</b> corresponding
+        award will be included in the resulting set.</p>
 
         <p>The following award types are supported:</p>
         <ul>

--- a/okapi/services/caches/search/all/docs.xml
+++ b/okapi/services/caches/search/all/docs.xml
@@ -262,6 +262,21 @@
         IDs. You should not use them. This parameter was implemented for
         internal use.</p>
     </opt>
+    <opt name='awarded_status' default='either'>
+        <p>Includes information about a "cache of the week/month etc." award
+        granted or not in the search criteria. Only some Opencaching sites
+        implement this feature. If you set the parameter to one of the following
+        values and this site does not implement it, it will not affect the
+        search result.</p>
+
+        <p>Should be one of the following:</p>
+        <ul>
+            <li><b>awarded_only</b> - only awarded caches will be returned,</li>
+            <li><b>notawarded_only</b> - only <b>not</b> awarded caches will be
+                returned,</li>
+            <li><b>either</b> - all caches will be returned.</li>
+        </ul>
+    </opt>
     <opt name='set_and'>
         <p>ID of a set previously created with the <b>search/save</b> method.
         If given, the results are

--- a/okapi/services/caches/search/all/docs.xml
+++ b/okapi/services/caches/search/all/docs.xml
@@ -263,17 +263,16 @@
         internal use.</p>
     </opt>
     <opt name='awarded'>
-        <p>Pipe separated list of award types. If given and not empty, an award
-        of selected type is added to filter constraints if it is applicable to
-        current Opencaching site. If a '-' character precedes the award type,
-        only caches <b>not granted</b> corresponding award will be included
-        in the resulting set, otherwise only caches <b>granted</b> corresponding
-        award will be included in the resulting set.</p>
+        <p>Pipe-separated list of award types. If given and not empty,
+        by default only caches will be included in the response which were
+        granted all of the specified awards. If a '-' character precedes an
+        award type, only caches that <b>not</b> received this award will be
+        included.</p>
 
         <p>The following award types are supported:</p>
         <ul>
             <li><b>cotp</b> - the Cache of the Period (week/month etc.) award.
-            Only some Opencaching sites implement this award and the period
+            Only some Opencaching sites implement this award, and the period
             depends on the particular site settings.</li>
         </ul>
     </opt>
@@ -298,7 +297,7 @@
         Have a peek at the <b>replicate</b> module if you need all the caches.</p>
     </opt>
     <opt name='order_by'>
-        <p>Pipe separated list of fields to order the results by. Prefix the field name with
+        <p>Pipe-separated list of fields to order the results by. Prefix the field name with
         a '-' sign to indicate a descending order.</p>
 
         <p>Currently, fields which you can order by include: <b>code</b>, <b>name</b>,


### PR DESCRIPTION
Extends the cache search filter parameters by an `awarded_status` one, which includes the `cache_titled` table in the search query, existing in opencaching-pl only. The term "awarded" used here seems to be more correct than "titled" used in table name.

Available values (see docs): `awarded_only`, `notawarded_only`, `either`.
The code formatting is based on the existing one in the same method.