### PR TITLE
NTR - remove curly braces #602

### DIFF
--- a/okapi/core/OAuth/OAuthSignatureMethod.php
+++ b/okapi/core/OAuth/OAuthSignatureMethod.php
@@ -49,7 +49,7 @@ abstract class OAuthSignatureMethod {
         $result = 0;
         $signatureLength = strlen($signature);
         for ($i = 0; $i < $signatureLength; $i++) {
-            $result |= ord($built{$i}) ^ ord($signature{$i});
+            $result |= ord($built[$i]) ^ ord($signature[$i]);
         }
 
         return $result == 0;


### PR DESCRIPTION
With this gist: https://gist.github.com/mathiasverraes/3096500 I checked all files. Only OAUthSignatureMethod was using curly braces.