### PR TITLE
Add a failsafe for errors caused by invalid cache names

### DIFF
--- a/okapi/services/caches/map/TileRenderer.php
+++ b/okapi/services/caches/map/TileRenderer.php
@@ -297,6 +297,10 @@ class TileRenderer
      */
     private static function wordwrap($font, $size, $maxWidth, $text)
     {
+        if (!is_string($text)) {
+            // Failsafe. In general, this should not happen.
+            $text = print_r($text, true);
+        }
         $words = explode(" ", $text);
         $lines = array();
         $line = "";
@@ -307,7 +311,12 @@ class TileRenderer
                 $word = $nextBonus." ".$word;
             $nextBonus = "";
             while (true) {
-                $bbox = imagettfbbox($size, 0, $font, $line.$word);
+                try {
+                    $bbox = imagettfbbox($size, 0, $font, $line.$word);
+                } catch (ErrorException $e) {
+                    // Failsafe. In general, this should not happen.
+                    return "error";
+                }
                 $width = $bbox[2]-$bbox[0];
                 if ($width <= $maxWidth) {
                     $line .= $word." ";


### PR DESCRIPTION
Context:

```
===== ERROR MESSAGE =====
ErrorException:
imagettfbbox(): Problem doing text layout
=========================

--- Stack trace ---
#0 [internal function]: okapi\core\OkapiErrorHandler::handle()
#1 /serve/www/oc_www/oc_www/okapi/services/caches/map/TileRenderer.php(310): imagettfbbox()
#2 /serve/www/oc_www/oc_www/okapi/services/caches/map/TileRenderer.php(363): okapi\services\caches\map\TileRenderer::wordwrap()
#3 /serve/www/oc_www/oc_www/okapi/services/caches/map/TileRenderer.php(195): okapi\services\caches\map\TileRenderer->get_caption()
#4 /serve/www/oc_www/oc_www/okapi/services/caches/map/TileRenderer.php(92): okapi\services\caches\map\TileRenderer->draw_cache()
#5 /serve/www/oc_www/oc_www/okapi/services/caches/map/tile/WebService.php(243): okapi\services\caches\map\TileRenderer->render()
#6 [internal function]: okapi\services\caches\map\tile\WebService::call()
#7 /serve/www/oc_www/oc_www/okapi/core/OkapiServiceRunner.php(142): call_user_func()
#8 /serve/www/oc_www/oc_www/okapi/Facade.php(100): okapi\core\OkapiServiceRunner::call()
#9 /serve/www/oc_www/oc_www/src/Controllers/MainMapAjaxController.php(129): okapi\Facade::service_display()
#10 [internal function]: src\Controllers\MainMapAjaxController->getMapTile()
#11 /serve/www/oc_www/oc_www/src/Utils/Uri/SimpleRouter.php(151): call_user_func_array()
#12 /serve/www/oc_www/oc_www/public/index.php(8): src\Utils\Uri\SimpleRouter::run()
#13 {main}
```