### PR TITLE
fix typo

### DIFF
--- a/okapi/services/attrs/attribute-definitions.xml
+++ b/okapi/services/attrs/attribute-definitions.xml
@@ -1065,7 +1065,7 @@ store these attributes in GPX <groundspeak:attribute> elements.
         <lang id="de">
             <name>Handicap: Rollstuhl</name>
             <desc>
-                Der Cache ist mit Rollstuhl/Rollator/Kiderwagen erreichbar.
+                Der Cache ist mit Rollstuhl/Rollator/Kinderwagen erreichbar.
             </desc>
         </lang>
         <lang id="nl">


### PR DESCRIPTION
in german "Kiderwagen" to "Kinderwagen"