### PR TITLE
services/caches/search/SearchAssistant.php: Fix issue with not found userIds

### DIFF
--- a/okapi/services/caches/search/SearchAssistant.php
+++ b/okapi/services/caches/search/SearchAssistant.php
@@ -234,8 +234,12 @@ class SearchAssistant
             }
             if (count($users) > 0) {
                 $user_ids = array();
-                foreach ($users as $user)
+                foreach ($users as $user) {
+                    if (!is_array($user)) {
+                        continue;
+                    }
                     $user_ids[] = $user['internal_id'];
+                }
                 $where_conds[] = "caches.user_id $operator ('".implode("','", array_map('\okapi\core\Db::escape_string', $user_ids))."')";
             } else if ($operator == "in")
                 $where_conds[] = "false";


### PR DESCRIPTION


  services/users/users may return null entries in the list of requested users
  It results in exception.

  Details:
  ===== ERROR MESSAGE =====
ErrorException:
Trying to access array offset on value of type null
=========================

--- Stack trace ---
#0 /srv/ocpl/okapi/services/caches/search/SearchAssistant.php(238): okapi\core\OkapiErrorHandler::handle()
#1 /srv/ocpl/okapi/services/caches/search/nearest/WebService.php(55): okapi\services\caches\search\SearchAssistant->prepare_common_search_params()
#2 [internal function]: okapi\services\caches\search\nearest\WebService::call()
#3 /srv/ocpl/okapi/core/OkapiServiceRunner.php(142): call_user_func()
#4 /srv/ocpl/okapi/services/caches/shortcuts/search_and_retrieve/WebService.php(67): okapi\core\OkapiServiceRunner::call()
#5 [internal function]: okapi\services\caches\shortcuts\search_and_retrieve\WebService::call()
#6 /srv/ocpl/okapi/core/OkapiServiceRunner.php(142): call_user_func()
#7 /srv/ocpl/okapi/views/method_call/View.php(19): okapi\core\OkapiServiceRunner::call()
#8 [internal function]: okapi\views\method_call\View::call()
#9 /srv/ocpl/okapi/OkapiScriptEntryPointController.php(50): call_user_func_array()
#10 /srv/ocpl/okapi/index.php(49): okapi\OkapiScriptEntryPointController::dispatch_request()
#11 {main}