### PR TITLE
Fix #615: [OKAPI] Compress all files in directory

### DIFF
--- a/okapi/services/replicate/ReplicateCommon.php
+++ b/okapi/services/replicate/ReplicateCommon.php
@@ -598,7 +598,7 @@ class ReplicateCommon
         $dumpfile_tarname = "okapi-dump.tar";
         $dumpfilename = $dumpfile_tarname.($use_bzip2 ? ".bz2" : ".gz");
         self::execute(
-            "tar --directory $dir -c".($use_bzip2 ? "j" : "z")."f $dir/$dumpfilename index.json ".implode(" ", $json_files),
+            "tar --directory $dir -c".($use_bzip2 ? "j" : "z")."f $dir/$dumpfilename --exclude=$dumpfilename .",
             $shell_output
         );
 


### PR DESCRIPTION
Instead of specifying all filenames to compress (and exploding `bash` argument size limit), why not use `tar` capabilities to discover all files in the directory itself?

From what I see, a fresh directory is created on line ~506, so I expect the directory to contains only the necessaries files.
This fix expect there is no other temporary files in the directory else they'll be included.

Non wanted files may be explicitly excluded using `--exclude=`, I've set the currently generated archive from being self included.

Ex:
```
$ mkdir /tmp/tt; cd /tmp/tt

$ touch index.json file1.json file2.json file3.json

$ ll
total 124
drwxrwxr-x    2 kumy kumy   4096 Oct 27 09:51 ./
drwxrwxrwt 1869 root root 114688 Oct 27 09:51 ../
-rw-rw-r--    1 kumy kumy    431 Oct 27 09:51 dumpfilename.tar.gz
-rw-rw-r--    1 kumy kumy      0 Oct 27 09:51 file1.json
-rw-rw-r--    1 kumy kumy      0 Oct 27 09:51 file2.json
-rw-rw-r--    1 kumy kumy      0 Oct 27 09:51 file3.json
-rw-rw-r--    1 kumy kumy      0 Oct 27 09:51 index.json

$ tar --directory /tmp/tt/ -czf /tmp/tt/dumpfilename.tar.gz --exclude=dumpfilename.tar.gz .

$ tar tf dumpfilename.tar.gz 
./
./file2.json
./index.json
./file3.json
./file1.json
```

I hope this help having this and our issue fixed ;)
(In case this PR is accepted, may you add explicitly the tag `hacktoberfest-accepted` to this PR so it will count for my stats. Thanks)