### PR TITLE
NTR - remove group_contact to prevent string cutting for private notes

### DIFF
--- a/okapi/services/caches/geocaches/WebService.php
+++ b/okapi/services/caches/geocaches/WebService.php
@@ -1117,7 +1117,7 @@ class WebService
                 # OCDE uses coordinates table (with type == 2) to store notes (this is somewhat weird).
 
                 $rs = Db::query("
-                    select cache_id, null as date, group_concat(description) as `desc`
+                    select cache_id, null as date, description as `desc`
                     from coordinates
                     where
                         type = 2  -- personal note


### PR DESCRIPTION
We have a strange issue in the c:geo application. The group_concat is cutting private notes cause of mysql default string limitations in group_contact. We don't need this cause we have no duplicate entries in coordinates.

For more details please see https://github.com/cgeo/cgeo/issues/13651