### PR TITLE
issue #628 save_user_coords

### DIFF
--- a/okapi/core/OkapiServiceRunner.php
+++ b/okapi/core/OkapiServiceRunner.php
@@ -39,6 +39,7 @@ class OkapiServiceRunner
         'services/caches/geocaches',
         'services/caches/mark',
         'services/caches/save_personal_notes',
+        'services/caches/save_user_coords',
         'services/caches/formatters/gpx',
         'services/caches/formatters/garmin',
         'services/caches/formatters/ggz',

--- a/okapi/services/caches/save_user_coords/WebService.php
+++ b/okapi/services/caches/save_user_coords/WebService.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace okapi\services\caches\save_user_coords;
+
+use okapi\core\Db;
+use okapi\core\Exception\ParamMissing;
+use okapi\core\Exception\InvalidParam;
+use okapi\core\Okapi;
+use okapi\core\OkapiServiceRunner;
+use okapi\core\Request\OkapiInternalRequest;
+use okapi\core\Request\OkapiRequest;
+use okapi\Settings;
+
+class WebService
+{
+    public static function options()
+    {
+        return array(
+            'min_auth_level' => 3
+        );
+    }
+
+    public static function call(OkapiRequest $request)
+    {
+
+        $user_coords = $request->get_parameter('user_coords');
+        if ($user_coords == null)
+            throw new ParamMissing('user_coords');
+        $parts = explode('|', $user_coords);
+        if (count($parts) != 2)
+            throw new InvalidParam('user_coords', "Expecting 2 pipe-separated parts, got ".count($parts).".");
+        foreach ($parts as &$part_ref)
+        {
+            if (!preg_match("/^-?[0-9]+(\.?[0-9]*)$/", $part_ref))
+                throw new InvalidParam('user_coords', "'$part_ref' is not a valid float number.");
+            $part_ref = floatval($part_ref);
+        }
+        list($latitude, $longitude) = $parts;
+
+        # Verify cache_code
+
+        $cache_code = $request->get_parameter('cache_code');
+        if ($cache_code == null)
+            throw new ParamMissing('cache_code');
+        $geocache = OkapiServiceRunner::call(
+            'services/caches/geocache',
+            new OkapiInternalRequest($request->consumer, $request->token, array(
+                'cache_code' => $cache_code,
+                'fields' => 'internal_id'
+            ))
+        );
+        $cache_id = $geocache['internal_id'];
+
+        self::update_notes($cache_id, $request->token->user_id, $latitude, $longitude);
+
+	$ret_value = 'ok';
+
+        $result = array(
+            'status' => $ret_value
+        );
+        return Okapi::formatted_response($request, $result);
+    }
+
+    private static function update_notes($cache_id, $user_id, $latitude, $longitude)
+    {
+        /* See:
+         *
+         * - https://github.com/OpencachingDeutschland/oc-server3/tree/development/htdocs/src/Oc/Libse/CacheNote
+         * - https://www.opencaching.de/okapi/devel/dbstruct
+         */
+
+        $rs = Db::query("
+            select max(id) as id
+            from coordinates
+            where
+                type = 2  -- personal note
+                and cache_id = '".Db::escape_string($cache_id)."'
+                and user_id = '".Db::escape_string($user_id)."'
+        ");
+        $id = null;
+        if($row = Db::fetch_assoc($rs)) {
+            $id = $row['id'];
+        }
+        if ($id == null) {
+            Db::query("
+                insert into coordinates (
+                    type, latitude, longitude, cache_id, user_id
+                ) values (
+                    2,
+                    '".Db::escape_string($latitude)."',
+                    '".Db::escape_string($longitude)."',
+                    '".Db::escape_string($cache_id)."',
+                    '".Db::escape_string($user_id)."'
+                )
+            ");
+        } else {
+            Db::query("
+                update coordinates
+                set latitude  = '".Db::escape_string($latitude)."',
+                    longitude = '".Db::escape_string($longitude)."',
+                where
+                    id = '".Db::escape_string($id)."'
+                    and type = 2
+            ");
+        }
+    }
+
+}

--- a/okapi/services/caches/save_user_coords/WebService.php
+++ b/okapi/services/caches/save_user_coords/WebService.php
@@ -46,10 +46,12 @@ class WebService
             'services/caches/geocache',
             new OkapiInternalRequest($request->consumer, $request->token, array(
                 'cache_code' => $cache_code,
-                'fields' => 'internal_id'
+                'fields' => 'internal_id|type'
             ))
         );
         $cache_id = $geocache['internal_id'];
+
+        self::validate_cache_type($geocache['type']);
 
         self::update_coordinates($cache_id, $request->token->user_id, $latitude, $longitude);
 
@@ -57,6 +59,22 @@ class WebService
             'success' => true
         );
         return Okapi::formatted_response($request, $result);
+    }
+
+    private static function validate_cache_type($cache_type)
+    {
+        if (Settings::get('OC_BRANCH') != 'oc.pl') {
+            return;
+        }
+
+        $allowed_types = array('Other', 'Quiz', 'Multi');
+
+        if (!in_array($cache_type, $allowed_types, true)) {
+            throw new InvalidParam(
+                'cache_code',
+                "User coordinates are not supported for cache type '$cache_type'."
+            );
+        }
     }
 
     private static function update_coordinates($cache_id, $user_id, $latitude, $longitude)

--- a/okapi/services/caches/save_user_coords/WebService.php
+++ b/okapi/services/caches/save_user_coords/WebService.php
@@ -92,7 +92,7 @@ class WebService
                         '".Db::escape_string($longitude)."',
                         '".Db::escape_string($cache_id)."',
                         '".Db::escape_string($user_id)."',
-                        '".Db::escape_string("")."'
+                        ''
                     )
                 ");
             } else {

--- a/okapi/services/caches/save_user_coords/WebService.php
+++ b/okapi/services/caches/save_user_coords/WebService.php
@@ -108,37 +108,26 @@ class WebService
         }
         else # oc.pl branch
         {
-            $rs = Db::query("
-                select max(id) as id
-                from cache_mod_cords
-                where
-                    cache_id    = '".Db::escape_string($cache_id)."'
-                    and user_id = '".Db::escape_string($user_id)."'
+            # cache_mod_cords uses a composite PK (cache_id, user_id) — no id column.
+            Db::query("
+                INSERT INTO cache_mod_cords (
+                    cache_id,
+                    user_id,
+                    latitude,
+                    longitude,
+                    date
+                ) VALUES (
+                    '".Db::escape_string($cache_id)."',
+                    '".Db::escape_string($user_id)."',
+                    '".Db::escape_string($latitude)."',
+                    '".Db::escape_string($longitude)."',
+                    NOW()
+                )
+                ON DUPLICATE KEY UPDATE
+                    latitude = VALUES(latitude),
+                    longitude = VALUES(longitude),
+                    date = NOW()
             ");
-            $id = null;
-            if($row = Db::fetch_assoc($rs)) {
-                $id = $row['id'];
-            }
-            if ($id == null) {
-                Db::query("
-                    insert into cache_mod_cords (
-                        cache_id, user_id, latitude, longitude
-                    ) values (
-                        '".Db::escape_string($cache_id)."',
-                        '".Db::escape_string($user_id)."',
-                        '".Db::escape_string($latitude)."',
-                        '".Db::escape_string($longitude)."'
-                    )
-                ");
-            } else {
-                Db::query("
-                    update cache_mod_cords
-                    set latitude  = '".Db::escape_string($latitude)."',
-                        longitude = '".Db::escape_string($longitude)."'
-                    where
-                        id = '".Db::escape_string($id)."'
-                ");
-            }
         }
     }
 }

--- a/okapi/services/caches/save_user_coords/docs.xml
+++ b/okapi/services/caches/save_user_coords/docs.xml
@@ -1,0 +1,29 @@
+<xml>
+    <brief>Update personal coordinates of a geocache</brief>
+    <issue-id>629</issue-id>
+    <desc>
+	<p>This method allows your users to update the coordinates of their
+	personal geocache coordinates.</p>
+
+        <p>Current personal coordinates for the geocache can be retrieved
+        using the <b>alt_wpts</b> field in the
+        <a href="%OKAPI:methodargref:services/caches/geocache#fields%">services/caches/geocache</a>
+        method.</p>
+    </desc>
+    <req name='cache_code'>
+        <p>Code of the geocache</p>
+    </req>
+    <req name='user_coords'>
+        <p>The coordinates are defined by a string in the format "lat|lon"</p>
+	<p>Use positive numbers for latitudes in the northern hemisphere and longitudes
+	in the eastern hemisphere (and negative for southern and western hemispheres
+	accordingly). These are full degrees with a dot as a decimal point (ex. "48.7|15.89").</p>
+    </req>
+    <common-format-params/>
+    <returns>
+        <p>A dictionary of the following structure:</p>
+        <ul>
+            <li>status - ok</li>
+        </ul>
+    </returns>
+</xml>

--- a/okapi/services/caches/save_user_coords/docs.xml
+++ b/okapi/services/caches/save_user_coords/docs.xml
@@ -23,7 +23,7 @@
     <returns>
         <p>A dictionary of the following structure:</p>
         <ul>
-            <li>status - ok</li>
+            <li>success - true</li>
         </ul>
     </returns>
 </xml>

--- a/okapi/services/caches/save_user_coords/docs.xml
+++ b/okapi/services/caches/save_user_coords/docs.xml
@@ -11,7 +11,10 @@
         method.</p>
     </desc>
     <req name='cache_code'>
-        <p>Code of the geocache</p>
+        <p>Code of the geocache.</p>
+        <p>Note: On OCPL-based sites, user coordinates are only supported for
+        caches of type <b>Multi</b>, <b>Quiz</b>, and <b>Other</b>. Supplying a
+        cache of any other type will result in an HTTP 400 error.</p>
     </req>
     <req name='user_coords'>
         <p>The coordinates are defined by a string in the format "lat|lon"</p>


### PR DESCRIPTION
This is about adding a new service endpoint. The platforms (opencaching.xx) provide the capabilities to maintain a personal cache notes field for each cache. In addition with this there is also a capability to store user provided coordinates for instance the coordinates that are the result of solving a puzzle.

The OKAPI provides a service to retrieve the personal caches notes and also the user_coords. It also provides a service to update the personal cache notes but not the user coords.

I have implemented a new service to fill this gap. First I thought about extending the already existing service

:: services/caches/save_personal_notes

however, to make sure that this doesn't create any adverse side effects for existing client applications I decided to implement a new service:
:: services/caches/save_user_coords.